### PR TITLE
fail-mode: can show fatal errors in the main window, not allowing much else to happen

### DIFF
--- a/src/astroid.cc
+++ b/src/astroid.cc
@@ -203,8 +203,10 @@ namespace Astroid {
     }
 
     /* output db location */
-    ustring db_path = ustring (notmuch_config().get<string> ("database.path"));
-    log << info << "notmuch db: " << db_path << endl;
+    if (!in_failure ()) {
+      ustring db_path = ustring (notmuch_config().get<string> ("database.path"));
+      log << info << "notmuch db: " << db_path << endl;
+    }
 
     /* set up static classes */
     Date::init ();
@@ -247,6 +249,8 @@ namespace Astroid {
   }
 
   void Astroid::main_test () {
+    _in_test = true;
+
     m_config = new Config (true);
 
     /* set up static classes */
@@ -266,7 +270,9 @@ namespace Astroid {
   }
 
   bool Astroid::in_test () {
-    return m_config->test;
+    /* should match m_config->test, but may be required before Config
+     * is instantiated */
+    return _in_test;
   }
 
   Astroid::~Astroid () {

--- a/src/astroid.cc
+++ b/src/astroid.cc
@@ -215,9 +215,6 @@ namespace Astroid {
     /* set up accounts */
     accounts = new AccountManager ();
 
-    /* set up contacts */
-    //contacts = new Contacts ();
-
     /* set up global actions */
     global_actions = new GlobalActions ();
 
@@ -258,9 +255,6 @@ namespace Astroid {
 
     /* set up accounts */
     accounts = new AccountManager ();
-
-    /* set up contacts */
-    //contacts = new Contacts ();
 
     /* set up global actions */
     global_actions = new GlobalActions ();

--- a/src/astroid.hh
+++ b/src/astroid.hh
@@ -48,6 +48,7 @@ namespace Astroid {
 
     protected:
       Config * m_config;
+      bool     _in_test;
       bool     _in_failure;
       bool     _failmode_shown;
       bool     _is_main_window_ready;

--- a/src/astroid.hh
+++ b/src/astroid.hh
@@ -23,6 +23,13 @@ namespace Astroid {
       const StandardPaths& standard_paths() const;
       bool  in_test ();
 
+      /* this is true if there has been a fatal error, this means
+       * that nothing more really can happen except closing astroid.
+       *
+       * a window with the fatal error is shown plus a log window */
+      bool in_failure ();
+      void fail (ustring);
+
       refptr<Gtk::Application> app;
 
       static const char* const version;
@@ -30,9 +37,6 @@ namespace Astroid {
 
       /* accounts */
       AccountManager * accounts;
-
-      /* contacts */
-      //Contacts * contacts;
 
       /* actions */
       GlobalActions * global_actions;
@@ -44,6 +48,10 @@ namespace Astroid {
 
     protected:
       Config * m_config;
+      bool     _in_failure;
+      bool     _failmode_shown;
+      bool     _is_main_window_ready;
+      ustring  fail_str;
 
     private:
       bool activated = false;

--- a/src/command_bar.cc
+++ b/src/command_bar.cc
@@ -39,9 +39,11 @@ namespace Astroid {
         );
 
     /* set up tags */
-    Db db (Db::DbMode::DATABASE_READ_ONLY);
-    db.load_tags ();
-    existing_tags = db.tags;
+    if (!astroid->in_failure ()) {
+      Db db (Db::DbMode::DATABASE_READ_ONLY);
+      db.load_tags ();
+      existing_tags = db.tags;
+    }
 
     tag_completion = refptr<TagCompletion>(new TagCompletion());
     search_completion = refptr<SearchCompletion>(new SearchCompletion());

--- a/src/config.cc
+++ b/src/config.cc
@@ -266,8 +266,17 @@ namespace Astroid {
         write_back_config ();
       }
     }
+    path nm_conf_path (config.get<std::string> ("astroid.notmuch_config"));
+
+    if (!exists (nm_conf_path)) {
+      log << fatal << "could not find notmuch config at: " << nm_conf_path.c_str ()
+        << ", please update the configuration variable: astroid.notmuch_config." << endl;
+      return;
+    }
+
+
     boost::property_tree::read_ini (
-      config.get<std::string> ("astroid.notmuch_config"),
+      nm_conf_path.c_str (),
       notmuch_config);
   }
 

--- a/src/log.cc
+++ b/src/log.cc
@@ -50,12 +50,18 @@ namespace Astroid {
     auto now_time_t = std::chrono::system_clock::to_time_t( now );
     auto now_tm     = std::localtime( &now_time_t );
 
+
     stringstream time_str;
     time_str << "("
          << setw(2) << setfill('0') << now_tm->tm_hour << ":"
          << setw(2) << setfill('0') << now_tm->tm_min << ":"
          << setw(2) << setfill('0') << now_tm->tm_sec << ")";
 
+    LogLine l (_next_level, time_str.str (), _next_line.str ());
+
+    if (_next_level == fatal) {
+      astroid->fail (_next_line.str ());
+    }
 
     lock_guard<mutex> grd_s (m_outstreams);
     for (auto &o : out_streams) {
@@ -67,8 +73,9 @@ namespace Astroid {
 # endif
     }
 
+
     lock_guard<mutex> grd (m_lines);
-    lines.push (LogLine (_next_level, time_str.str (), _next_line.str()));
+    lines.push (l);
 
     _next_line.str (string());
     _next_line.clear ();
@@ -92,6 +99,7 @@ namespace Astroid {
       case info:  return "info ";
       case warn:  return "warn ";
       case error: return "ERROR";
+      case fatal: return "FATAL";
       case test:  return "TEST ";
       default:    return "unknown error level!";
     }

--- a/src/log.hh
+++ b/src/log.hh
@@ -22,6 +22,7 @@ namespace Astroid {
     info,
     warn,
     error,
+    fatal,
     test,
   };
 

--- a/src/main_window.cc
+++ b/src/main_window.cc
@@ -216,6 +216,7 @@ namespace Astroid {
     keys.register_key ("F", "main_window.search",
         "Search",
         [&] (Key) {
+          if (astroid->in_failure ()) return true;
           enable_command (CommandBar::CommandMode::Search, "", NULL);
           return true;
         });
@@ -223,6 +224,7 @@ namespace Astroid {
     keys.register_key ("L", "main_window.search_tag",
         "Search for tag:",
         [&] (Key) {
+          if (astroid->in_failure ()) return true;
           enable_command (CommandBar::CommandMode::Search, "tag:", NULL);
           return true;
         });
@@ -254,6 +256,7 @@ namespace Astroid {
     keys.register_key ("m", "main_window.new_mail",
         "Compose new mail",
         [&] (Key) {
+          if (astroid->in_failure ()) return true;
           add_mode (new EditMessage (this));
           return true;
         });
@@ -261,6 +264,7 @@ namespace Astroid {
     keys.register_key ("P", "main_window.poll",
         "Start manual poll",
         [&] (Key) {
+          if (astroid->in_failure ()) return true;
           astroid->poll->poll ();
           return true;
         });
@@ -268,6 +272,7 @@ namespace Astroid {
     keys.register_key ("M-p", "main_window.toggle_auto_poll",
         "Toggle auto poll",
         [&] (Key) {
+          if (astroid->in_failure ()) return true;
           astroid->poll->toggle_auto_poll ();
           return true;
         });
@@ -275,6 +280,7 @@ namespace Astroid {
     keys.register_key ("O", "main_window.open_new_window",
         "Open new main window",
         [&] (Key) {
+          if (astroid->in_failure ()) return true;
           astroid->open_new_window ();
           return true;
         });
@@ -423,7 +429,7 @@ namespace Astroid {
 
     //log << debug << "mw: grab modal to: " << n << endl;
 
-    if (has_focus() || (get_focus() && get_focus()->has_focus())) {
+    if (has_toplevel_focus() || (get_focus() && get_focus()->has_focus())) {
       /* we have focus */
       ((Mode*) notebook.get_nth_page (n))->grab_modal();
     } else {
@@ -454,15 +460,16 @@ namespace Astroid {
   }
 
   bool MainWindow::on_my_focus_in_event (GdkEventFocus * /* event */) {
-    if (active) set_active (current);
+    if (has_toplevel_focus () && active) set_active (current);
     //log << debug << "mw: focus-in: " << id << endl;
     return false;
   }
 
   bool MainWindow::on_my_focus_out_event (GdkEventFocus * /* event */) {
     //log << debug << "mw: focus-out: " << id << endl;
-    if ((current < notebook.get_n_pages ()) && (current >= 0))
-      ((Mode*) notebook.get_nth_page (current))->release_modal();
+    if (!has_toplevel_focus () &&
+        (current < notebook.get_n_pages ()) && (current >= 0))
+        ((Mode*) notebook.get_nth_page (current))->release_modal();
     return false;
   }
 }

--- a/src/modes/fail_mode.cc
+++ b/src/modes/fail_mode.cc
@@ -1,0 +1,56 @@
+# include <iostream>
+
+# include "main_window.hh"
+# include "mode.hh"
+# include "fail_mode.hh"
+# include "log_view.hh"
+# include "astroid.hh"
+
+using namespace std;
+
+namespace Astroid {
+  FailMode::FailMode (MainWindow * mw, ustring err) : Mode (mw) {
+    set_label ("Oh dear!");
+
+    invincible = true;
+
+    Gtk::VBox * vb = Gtk::manage (new Gtk::VBox ());
+
+    Gtk::Image * im = Gtk::manage (new Gtk::Image ());
+    im->set_from_icon_name ("dialog-warning-symbolic", Gtk::ICON_SIZE_DIALOG);
+    vb->pack_start (*im, false, false, 5);
+
+    scroll.add (fail_text);
+    vb->pack_start (scroll, true, true, 5);
+
+    pack_start (*vb, true, true, 5);
+
+    lv = Gtk::manage (new LogView (mw));
+    pack_end (*lv, true, true, 5);
+
+    ustring errmsg = ustring::compose (
+        "<i>Oh dear! There seems to have been a incident...</i>\n"
+        "\n"
+        "<span color=\"pink\">%1</span>\n"
+        "\n"
+        "See the log below for more information.\n"
+        "\n"
+        "Please check the wiki (<a href=\"http://https://github.com/gauteh/astroid/wiki\">https://github.com/gauteh/astroid/wiki</a>) if you\n"
+        "can find a solution there. If you think this is a bug, please report\n"
+        "it to: <a href=\"https://github.com/gauteh/astroid\">https://github.com/gauteh/astroid</a>."
+        , err);
+
+    fail_text.set_markup (errmsg);
+
+    show_all ();
+  }
+
+  void FailMode::grab_modal () {
+    lv->grab_modal ();
+  }
+
+  void FailMode::release_modal () {
+    lv->release_modal ();
+  }
+};
+

--- a/src/modes/fail_mode.cc
+++ b/src/modes/fail_mode.cc
@@ -42,6 +42,8 @@ namespace Astroid {
 
     fail_text.set_markup (errmsg);
 
+    fail_text.set_line_wrap (true);
+
     show_all ();
   }
 

--- a/src/modes/fail_mode.hh
+++ b/src/modes/fail_mode.hh
@@ -1,0 +1,24 @@
+# pragma once
+
+# include <gtkmm.h>
+# include <webkit/webkit.h>
+
+# include "astroid.hh"
+# include "proto.hh"
+# include "mode.hh"
+
+namespace Astroid {
+  class FailMode : public Mode {
+    public:
+      FailMode (MainWindow *, ustring err);
+
+      Gtk::ScrolledWindow scroll;
+      Gtk::Label fail_text;
+      LogView * lv;
+
+      /* mode */
+      virtual void grab_modal () override;
+      virtual void release_modal () override;
+  };
+}
+

--- a/src/modes/keybindings.hh
+++ b/src/modes/keybindings.hh
@@ -64,7 +64,7 @@ namespace Astroid {
       void set_prefix (ustring title, ustring prefix);
 
       ustring title; /* title of keybinding set */
-      bool loghandle = false; /* log handling */
+      bool loghandle; /* log handling, set in .cc */
 
       typedef std::pair<Key, std::function<bool (Key)>> KeyBinding;
 

--- a/src/modes/log_view.cc
+++ b/src/modes/log_view.cc
@@ -31,7 +31,6 @@ namespace Astroid {
     show_all_children ();
 
     log.add_log_view (this);
-    log << debug << "log window ready." << endl;
 
     keys.title = "Log view";
     keys.register_key ("j", { Key (GDK_KEY_Down) },
@@ -125,7 +124,7 @@ namespace Astroid {
         time_str,
         Glib::Markup::escape_text(s));
 
-    if (lvl == error) {
+    if (lvl == error || lvl == fatal) {
       row[m_columns.m_col_str] = "<span color=\"red\">" + l + "</span>";
     } else if (lvl == warn) {
       row[m_columns.m_col_str] = "<span color=\"pink\">" + l + "</span>";

--- a/src/modes/mode.cc
+++ b/src/modes/mode.cc
@@ -119,8 +119,7 @@ namespace Astroid {
     }
 
     /* allow events to be sent to the mode */
-    release_modal ();
-    grab_focus ();
+    main_window->ungrab_active ();
 
     yes_no_waiting = true;
     yes_no_closure = closure;
@@ -141,7 +140,7 @@ namespace Astroid {
     }
 
     /* return modal to original mode */
-    grab_modal ();
+    main_window->grab_active (main_window->current);
 
     if (yes_no_waiting) {
       if (yes_no_closure != NULL) {
@@ -241,7 +240,7 @@ namespace Astroid {
   }
 
   bool Mode::on_key_press_event (GdkEventKey *event) {
-    /* log << debug << "mode: key: " << typeid (*this).name () << endl; */
+    /* log << debug << "mode: key: " << typeid (*this).name () << std::endl; */
 
     /* we need to check all parent widget modes too, before checking for the
      * default keys. */

--- a/src/poll.cc
+++ b/src/poll.cc
@@ -47,7 +47,7 @@ namespace Astroid {
   }
 
   bool Poll::periodic_polling () {
-    if (auto_polling_enabled) {
+    if (auto_polling_enabled && !astroid->in_failure ()) {
       chrono::duration<double> elapsed = chrono::steady_clock::now() - last_poll;
 
       if (elapsed.count () >= poll_interval) {


### PR DESCRIPTION
e.g. #63.
