### PR TITLE
crypto-2: ui: colour changes and padding to crypto containers

### DIFF
--- a/ui/thread-view.scss
+++ b/ui/thread-view.scss
@@ -634,11 +634,11 @@ body.nohide .email .compressed_note > span {
 }
 
 .attachment .encrypted {
-  border: 1px dashed gray !important;
+  border: 1px dashed green !important;
 }
 
 .attachment .signed {
-  border: 1px dashed blue !important;
+  border: 1px dashed orange !important;
 }
 
 #encrypt_container {
@@ -659,12 +659,14 @@ body.nohide .email .compressed_note > span {
 
 .encrypted {
   display: block;
-  border: 2px dashed gray;
+  border: 1px dashed green;
+  padding: 10px;
 }
 
 .signed {
   display: block;
-  border: 2px dashed blue;
+  border: 1px dashed orange;
+  padding: 10px;
 }
 
 #sibling_container {


### PR DESCRIPTION
use orange for signed, green for encrypted
add padding between border and text to containers
make border thinner (1px instead of 2px)