### PR TITLE
fix #151: revamp default keybindings

### DIFF
--- a/src/main_window.cc
+++ b/src/main_window.cc
@@ -181,7 +181,8 @@ namespace Astroid {
           return true;
         });
 
-    keys.register_key ("b", "main_window.next_page",
+    keys.register_key ("l", { "b" },
+        "main_window.next_page",
         "Next page",
         [&] (Key)
         {
@@ -193,7 +194,8 @@ namespace Astroid {
           return true;
         });
 
-    keys.register_key ("B", "main_window.previous_page",
+    keys.register_key ("h", { "B" },
+        "main_window.previous_page",
         "Previous page",
         [&] (Key) {
           if (notebook.get_current_page() == 0)
@@ -254,21 +256,22 @@ namespace Astroid {
         "Jump to page 0",
         bind (&MainWindow::jump_to_page, this, _1, 0));
 
-    keys.register_key ("x", "main_window.close_page",
+    keys.register_key ("C-w", "main_window.close_page",
         "Close mode (or window if other windows are open)",
         [&] (Key) {
           close_page ();
           return true;
         });
 
-    keys.register_key ("X", "main_window.close_page_force",
+    keys.register_key ("C-W", "main_window.close_page_force",
         "Force close mode (or window if other windows are open)",
         [&] (Key) {
           close_page (true);
           return true;
         });
 
-    keys.register_key ("F", "main_window.search",
+    keys.register_key ("o",
+        "main_window.search",
         "Search",
         [&] (Key) {
           enable_command (CommandBar::CommandMode::Search, "", NULL);
@@ -334,7 +337,7 @@ namespace Astroid {
           return true;
         });
 
-    keys.register_key ("O", "main_window.open_new_window",
+    keys.register_key ("C-o", "main_window.open_new_window",
         "Open new main window",
         [&] (Key) {
           astroid->open_new_window ();

--- a/src/modes/thread_index/thread_index.cc
+++ b/src/modes/thread_index/thread_index.cc
@@ -93,7 +93,7 @@ namespace Astroid {
           return true;
         });
 
-    keys.register_key ("v", "thread_index.refine_query", "Refine query",
+    keys.register_key ("O", "thread_index.refine_query", "Refine query",
         [&] (Key) {
           if (!invincible) {
             main_window->enable_command (CommandBar::CommandMode::Search,

--- a/src/modes/thread_index/thread_index_list_view.cc
+++ b/src/modes/thread_index/thread_index_list_view.cc
@@ -430,7 +430,7 @@ namespace Astroid {
                              "Toggle spam",
                              bind (&ThreadIndexListView::multi_key_handler, this, MSpam, _1));
 
-    multi_keys.register_key ("l",
+    multi_keys.register_key ("+",
                              "thread_index.multi.tag",
                              "Tag",
                              bind (&ThreadIndexListView::multi_key_handler, this, MTag, _1));
@@ -446,7 +446,7 @@ namespace Astroid {
                              "Toggle marked",
                              bind (&ThreadIndexListView::multi_key_handler, this, MToggle, _1));
 
-    keys->register_key ("+",
+    keys->register_key (";",
           "thread_index.multi",
           "Apply action to marked threads",
           [&] (Key k) {
@@ -823,7 +823,8 @@ namespace Astroid {
           return true;
         });
 
-    keys->register_key ("l", "thread_index.label",
+    keys->register_key ("+",
+        "thread_index.tag",
         "Edit tags for thread",
         [&] (Key) {
           auto thread = get_current_thread ();

--- a/src/modes/thread_view/thread_view.cc
+++ b/src/modes/thread_view/thread_view.cc
@@ -2034,11 +2034,16 @@ namespace Astroid {
           return false;
         });
 
-    keys.register_key ("o", "thread_view.open",
+    /*
+     *
+     * This can be achieved using Enter
+
+    keys.register_key ("O", "thread_view.open",
         "Open attachment or message",
         [&] (Key) {
           return element_action (EOpen);
         });
+    */
 
     keys.register_key ("e", "thread_view.expand",
         "Toggle expand",
@@ -2236,7 +2241,8 @@ namespace Astroid {
         });
 
 
-    keys.register_key ("C-f", "thread_view.flat",
+    keys.register_key ("C-F",
+        "thread_view.flat",
         "Toggle flat or indented view of messages",
         [&] (Key) {
           indent_messages = !indent_messages;
@@ -2418,7 +2424,7 @@ namespace Astroid {
           return true;
         });
 
-    keys.register_key ("+",
+    keys.register_key (";",
           "thread_view.multi",
           "Apply action to marked threads",
           [&] (Key k) {
@@ -2481,7 +2487,7 @@ namespace Astroid {
           return true;
         });
 
-    keys.register_key ("l",
+    keys.register_key ("+",
         "thread_view.tag_message",
         "Tag message",
         [&] (Key) {
@@ -2534,7 +2540,8 @@ namespace Astroid {
           return true;
         });
 
-    keys.register_key ("/", "thread_view.search.search",
+    keys.register_key ("C-f",
+        "thread_view.search.search",
         "Search for text",
         sigc::mem_fun (this, &ThreadView::search));
 


### PR DESCRIPTION
thread_index.label is now moved to thread_index.tag, update your custom
keybindings.

Changes to default keybindings:
```
main_window.next_page = b
main_window.next_page = l

main_window.previous_page = B
main_window.previous_page = h

main_window.close_page = C-w
main_window.close_page_force = C-W
main_window.open_new_window = C-o

main_window.search = o
thread_index.refine_query = O

thread_index.tag = +
thread_index.multi = ;
thread_index.multi.tag = +

thread_view.multi = ;
thread_view.tag_message = +
thread_view.flat = C-F
thread_view.search.search = C-f

```

thread_view.open is removed (used to be 'o'), it can all be achieved by
using Enter.