### PR TITLE
Open drop-down terminal with '|'

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -236,6 +236,10 @@ if not conf.CheckPKG('webkitgtk-3.0'):
   print "webkitgtk not found."
   Exit (1)
 
+if not conf.CheckPKG ('vte-2.91'):
+  print ("vte3 not found.")
+  Exit (1)
+
 if not disable_libsass:
   if conf.CheckLibWithHeader ('libsass', 'sass_context.h', 'c'):
     env.AppendUnique (CPPFLAGS = [ '-DSASSCTX_SASS_CONTEXT_H' ])
@@ -303,6 +307,7 @@ env.ParseConfig ('pkg-config --libs --cflags gmime-2.6')
 env.ParseConfig ('pkg-config --libs --cflags webkitgtk-3.0')
 if not disable_libsass:
   env.ParseConfig ('pkg-config --libs --cflags libsass')
+env.ParseConfig ('pkg-config --libs --cflags vte-2.91')
 
 if not conf.CheckLib ('boost_filesystem', language = 'c++'):
   print "boost_filesystem does not seem to be installed."

--- a/src/main_window.cc
+++ b/src/main_window.cc
@@ -4,6 +4,8 @@
 # include <gtkmm/widget.h>
 # include <gtkmm/notebook.h>
 
+# include <vte/vte.h>
+
 # include "astroid.hh"
 # include "poll.hh"
 # include "main_window.hh"
@@ -18,6 +20,12 @@
 # include "actions/action_manager.hh"
 
 using namespace std;
+
+extern "C" {
+  void mw_on_terminal_child_exit (VteTerminal * t, gint a, gpointer mw) {
+    ((Astroid::MainWindow *) mw)->on_terminal_child_exit (t, a);
+  }
+}
 
 namespace Astroid {
   atomic<uint> MainWindow::nextid (0);
@@ -138,6 +146,11 @@ namespace Astroid {
     rev_multi->set_reveal_child (false);
     vbox.pack_end (*rev_multi, false, true, 0);
 
+    /* terminal */
+    rev_terminal = Gtk::manage (new Gtk::Revealer ());
+    rev_terminal->set_transition_type (Gtk::REVEALER_TRANSITION_TYPE_SLIDE_UP);
+    rev_terminal->set_reveal_child (false);
+    vbox.pack_end (*rev_terminal, false, true, 0);
 
     add (vbox);
 
@@ -350,6 +363,13 @@ namespace Astroid {
           return true;
         });
 
+    keys.register_key ("|", "main_window.open_terminal",
+        "Open terminal",
+        [&] (Key) {
+          enable_terminal ();
+          return true;
+        });
+
     // }}}
   }
 
@@ -393,14 +413,14 @@ namespace Astroid {
   void MainWindow::enable_command (CommandBar::CommandMode m, ustring title, ustring cmd, function<void(ustring)> f) {
     ungrab_active ();
     command.enable_command (m, title, cmd, f);
-    is_command = true;
+    active_mode = Command;
     command.add_modal_grab ();
   }
 
   void MainWindow::enable_command (CommandBar::CommandMode m, ustring cmd, function<void(ustring)> f) {
     ungrab_active ();
     command.enable_command (m, cmd, f);
-    is_command = true;
+    active_mode = Command;
     command.add_modal_grab ();
   }
 
@@ -408,7 +428,7 @@ namespace Astroid {
     // hides itself
     command.remove_modal_grab();
     set_active (current);
-    is_command = false;
+    active_mode = Window;
   }
 
   void MainWindow::on_command_mode_changed () {
@@ -416,6 +436,76 @@ namespace Astroid {
       disable_command ();
     }
   }
+
+  /* Terminal {{{ */
+  void MainWindow::enable_terminal () {
+    rev_terminal->set_reveal_child (true);
+    ungrab_active ();
+    active_mode = Terminal;
+
+    vte_term = vte_terminal_new ();
+    gtk_container_add (GTK_CONTAINER(rev_terminal->gobj ()), vte_term);
+    rev_terminal->show_all ();
+
+    GError * err = NULL;
+
+    vte_terminal_set_size (VTE_TERMINAL (vte_term), 1, 10);
+
+    /* start shell */
+    GPid pid;
+    /* GCancellable * c = g_cancellable_new (); */
+
+    char * shell = vte_get_user_shell ();
+
+    char * args[2] = { shell, NULL };
+    char * envs[1] = { NULL };
+
+    LOG (info) << "mw: starting terminal..: " << shell;
+
+    vte_terminal_spawn_sync (VTE_TERMINAL(vte_term),
+        VTE_PTY_DEFAULT,
+        bfs::current_path ().c_str(),
+        args,
+        envs,
+        G_SPAWN_DEFAULT,
+        NULL,
+        NULL,
+        &pid,
+        NULL,
+        (err = NULL, &err));
+
+
+    gtk_widget_grab_focus (vte_term);
+    gtk_grab_add (vte_term);
+
+    if (err) {
+      LOG (error) << "mw: terminal: " << err->message;
+      disable_terminal ();
+    } else {
+      LOG (debug) << "mw: terminal started.";
+      g_signal_connect (vte_term, "child-exited",
+          G_CALLBACK (mw_on_terminal_child_exit),
+          (gpointer) this);
+
+    }
+  }
+
+  void MainWindow::disable_terminal () {
+    LOG (info) << "mw: disabling terminal..";
+    rev_terminal->set_reveal_child (false);
+    set_active (current);
+    active_mode = Window;
+    gtk_grab_remove (vte_term);
+
+    gtk_widget_destroy (vte_term);
+  }
+
+  void MainWindow::on_terminal_child_exit (VteTerminal *, gint) {
+    LOG (info) << "mw: terminal exited.";
+    disable_terminal ();
+  }
+
+  // }}}
 
   void MainWindow::quit () {
     LOG (info) << "mw: quit: " << id;
@@ -485,6 +575,9 @@ namespace Astroid {
       }
 
       return true; // swallow all keys
+
+    } else if (active_mode == Terminal) {
+      return true;
     }
 
     return false;
@@ -493,7 +586,7 @@ namespace Astroid {
   bool MainWindow::on_key_press (GdkEventKey * event) {
     if (mode_key_handler (event)) return true;
 
-    if (is_command) {
+    if (active_mode == Command) {
       command.command_handle_event (event);
       return true;
     }

--- a/src/main_window.cc
+++ b/src/main_window.cc
@@ -21,11 +21,13 @@
 
 using namespace std;
 
+# ifndef DISABLE_VTE
 extern "C" {
   void mw_on_terminal_child_exit (VteTerminal * t, gint a, gpointer mw) {
     ((Astroid::MainWindow *) mw)->on_terminal_child_exit (t, a);
   }
 }
+# endif
 
 namespace Astroid {
   atomic<uint> MainWindow::nextid (0);
@@ -147,10 +149,12 @@ namespace Astroid {
     vbox.pack_end (*rev_multi, false, true, 0);
 
     /* terminal */
+# ifndef DISABLE_VTE
     rev_terminal = Gtk::manage (new Gtk::Revealer ());
     rev_terminal->set_transition_type (Gtk::REVEALER_TRANSITION_TYPE_SLIDE_UP);
     rev_terminal->set_reveal_child (false);
     vbox.pack_end (*rev_terminal, false, true, 0);
+# endif
 
     add (vbox);
 
@@ -363,12 +367,14 @@ namespace Astroid {
           return true;
         });
 
+# ifndef DISABLE_VTE
     keys.register_key ("|", "main_window.open_terminal",
         "Open terminal",
         [&] (Key) {
           enable_terminal ();
           return true;
         });
+# endif
 
     // }}}
   }
@@ -438,6 +444,7 @@ namespace Astroid {
   }
 
   /* Terminal {{{ */
+# ifndef DISABLE_VTE
   void MainWindow::enable_terminal () {
     rev_terminal->set_reveal_child (true);
     ungrab_active ();
@@ -504,6 +511,8 @@ namespace Astroid {
     LOG (info) << "mw: terminal exited.";
     disable_terminal ();
   }
+
+# endif
 
   // }}}
 

--- a/src/main_window.hh
+++ b/src/main_window.hh
@@ -8,6 +8,7 @@
 # include <gtkmm/notebook.h>
 
 # include <vte/vte.h>
+# include <boost/filesystem.hpp>
 
 # include "proto.hh"
 # include "command_bar.hh"
@@ -15,9 +16,12 @@
 # include "modes/keybindings.hh"
 # include "actions/action_manager.hh"
 
+namespace bfs = boost::filesystem;
+
 # ifndef DISABLE_VTE
 extern "C" {
   void mw_on_terminal_child_exit (VteTerminal *, gint, gpointer);
+  void mw_on_terminal_commit (VteTerminal *, gchar **, guint, gpointer);
 }
 # endif
 
@@ -74,9 +78,13 @@ namespace Astroid {
 
       /* terminal */
 # ifndef DISABLE_VTE
+      GPid      terminal_pid;
+      bfs::path terminal_cwd;
+
       void enable_terminal ();
       void disable_terminal ();
       void on_terminal_child_exit (VteTerminal *, gint);
+      void on_terminal_commit (VteTerminal*, gchar **, guint);
 
     private:
       Gtk::Revealer * rev_terminal;

--- a/src/main_window.hh
+++ b/src/main_window.hh
@@ -15,9 +15,11 @@
 # include "modes/keybindings.hh"
 # include "actions/action_manager.hh"
 
+# ifndef DISABLE_VTE
 extern "C" {
   void mw_on_terminal_child_exit (VteTerminal *, gint, gpointer);
 }
+# endif
 
 namespace Astroid {
   class Notebook : public Gtk::Notebook {
@@ -54,7 +56,9 @@ namespace Astroid {
       typedef enum _active {
         Window,
         Command,
+# ifndef DISABLE_VTE
         Terminal,
+# endif
       } Active;
 
       /* command bar */
@@ -69,6 +73,7 @@ namespace Astroid {
       void on_command_mode_changed ();
 
       /* terminal */
+# ifndef DISABLE_VTE
       void enable_terminal ();
       void disable_terminal ();
       void on_terminal_child_exit (VteTerminal *, gint);
@@ -76,6 +81,7 @@ namespace Astroid {
     private:
       Gtk::Revealer * rev_terminal;
       GtkWidget *     vte_term;
+# endif
 
     public:
       /* actions */

--- a/src/main_window.hh
+++ b/src/main_window.hh
@@ -7,11 +7,17 @@
 # include <gtkmm/window.h>
 # include <gtkmm/notebook.h>
 
+# include <vte/vte.h>
+
 # include "proto.hh"
 # include "command_bar.hh"
 # include "modes/mode.hh"
 # include "modes/keybindings.hh"
 # include "actions/action_manager.hh"
+
+extern "C" {
+  void mw_on_terminal_child_exit (VteTerminal *, gint, gpointer);
+}
 
 namespace Astroid {
   class Notebook : public Gtk::Notebook {
@@ -45,10 +51,16 @@ namespace Astroid {
       Gtk::Box vbox;
       Notebook notebook;
 
+      typedef enum _active {
+        Window,
+        Command,
+        Terminal,
+      } Active;
+
       /* command bar */
       CommandBar command;
 
-      bool is_command = false;
+      Active active_mode = Window;
       void enable_command (CommandBar::CommandMode, ustring,
           std::function<void(ustring)>);
       void enable_command (CommandBar::CommandMode, ustring, ustring,
@@ -56,6 +68,16 @@ namespace Astroid {
       void disable_command ();
       void on_command_mode_changed ();
 
+      /* terminal */
+      void enable_terminal ();
+      void disable_terminal ();
+      void on_terminal_child_exit (VteTerminal *, gint);
+
+    private:
+      Gtk::Revealer * rev_terminal;
+      GtkWidget *     vte_term;
+
+    public:
       /* actions */
       ActionManager * actions;
 


### PR DESCRIPTION
Open a drop-down terminal with '|', useful in combination with 'Y' and patches.
