### PR TITLE
Move to system's default sans-serif font

### DIFF
--- a/ui/thread-view.scss
+++ b/ui/thread-view.scss
@@ -34,15 +34,15 @@
 }
 
 @if not(global-variable-exists(font-mono)) {
-  $font-mono: "Input Mono", "Inconsolata", monospace !global;
+  $font-mono: monospace !global;
 }
 
 @if not(global-variable-exists(font-sans)) {
-  $font-sans: "Input Sans", "Roboto", sans-serif !global;
+  $font-sans: sans-serif !global;
 }
 
 @if not(global-variable-exists(font-family-default)) {
-  $font-family-default: $font-mono !global;
+  $font-family-default: $font-sans !global;
 }
 
 /* Colours */


### PR DESCRIPTION
I didn't realise that my personal font preferences were still in the default astroid message style. This removes references to custom fonts and instead use the system's default fonts. This also moves to a sans serif font rather than a monospace font by default.