### PR TITLE
Improve poll.sh example

### DIFF
--- a/examples/poll.sh
+++ b/examples/poll.sh
@@ -1,8 +1,42 @@
-#! /bin/bash
+#!/usr/bin/env bash
+#
+# poll.sh - An example poll script for astroid.
+#
+# Intended to be run by astroid. See the following link for more information:
+# https://github.com/astroidmail/astroid/wiki/Polling
+#
 
-# poll script for astroid
+# Exit as soon as one of the commands fail.
+set -e
 
-offlineimap || exit $?
 
-notmuch new || exit $?
+# Fetch new mail.
+offlineimap
+
+# Import new mail into the notmuch database.
+notmuch new
+
+
+# Here follow some examples of processing the new mail. The respective section
+# of code needs to be uncommented to be enabled. See also notmuch-hooks(5) for
+# an alternative place to put these commands.
+
+
+# Automatic tagging of new mail. See notmuch-tag(1) for details.
+
+#notmuch tag --batch <<EOF
+#
+# # Tag urgent mail
+# +urgent subject:URGENT
+#
+# # Tag all mail from GitHub as "work"
+# +work from:github
+#
+#EOF
+
+
+# Notify user of new mail. See the following link for more information:
+# https://github.com/astroidmail/astroid/wiki/Desktop-notification
+
+#notifymuch
 

--- a/examples/poll.sh
+++ b/examples/poll.sh
@@ -5,10 +5,12 @@
 # Intended to be run by astroid. See the following link for more information:
 # https://github.com/astroidmail/astroid/wiki/Polling
 #
+# In particular, in order for this script to be run by astroid, it needs to be
+# located at ~/.config/astroid/poll.sh
+#
 
 # Exit as soon as one of the commands fail.
 set -e
-
 
 # Fetch new mail.
 offlineimap
@@ -16,27 +18,7 @@ offlineimap
 # Import new mail into the notmuch database.
 notmuch new
 
-
-# Here follow some examples of processing the new mail. The respective section
-# of code needs to be uncommented to be enabled. See also notmuch-hooks(5) for
-# an alternative place to put these commands.
-
-
-# Automatic tagging of new mail. See notmuch-tag(1) for details.
-
-#notmuch tag --batch <<EOF
-#
-# # Tag urgent mail
-# +urgent subject:URGENT
-#
-# # Tag all mail from GitHub as "work"
-# +work from:github
-#
-#EOF
-
-
-# Notify user of new mail. See the following link for more information:
-# https://github.com/astroidmail/astroid/wiki/Desktop-notification
-
-#notifymuch
+# Here you can process the mail in any way you see fit. See the following link
+# for examples:
+# https://github.com/astroidmail/astroid/wiki/Processing-mail
 


### PR DESCRIPTION
This is an attempt at improving the poll.sh example. In particular:
- Use `/usr/bin/env` bash instead of `/bin/bash`, as that is more portable
- Use `set -e` instead of `|| exit $?` after each command
- Add comments and examples

A few notes and questions before this is ready:
- Are there more examples we want to include? Whether we include them here or not, it would be nice to know about them. At the very least someone should add them to the Wiki.
- Am I using `notifymuch` correctly? I didn't manage to install it, and so haven't tested that piece of code.
- @gauteh had a mechanism for tagging only incoming mail. Specifically, there was a tag 'new' on incoming mail that he could target in his tagging script, which he then removed at the end of the script. As far as I can see this isn't standard [[1]](https://notmuchmail.org/pipermail/notmuch/2009/000767.html), and I saw some arguments against doing this. Also wonder if it makes the example unnecessarily complex. Maybe you could elaborate on where/how the 'new' tag is added?
- Does someone have better examples for the automatic tagging script?
