### PR TITLE
change from () to <> for email display

### DIFF
--- a/src/modes/thread_view/thread_view.cc
+++ b/src/modes/thread_view/thread_view.cc
@@ -1659,7 +1659,7 @@ namespace Astroid {
         }
 
         value +=
-          ustring::compose ("<a href=\"mailto:%3\">%4%1%5 (%2)</a>",
+          ustring::compose ("<a href=\"mailto:%3\">%4%1%5 &lt;%2&gt;</a>",
             Glib::Markup::escape_text (address.fail_safe_name ()),
             Glib::Markup::escape_text (address.email ()),
             Glib::Markup::escape_text (address.full_address()),


### PR DESCRIPTION
i consider <> as a convention / pattern to display / denote email addresses so i changed it in astroid accordingly. what do you think?