### PR TITLE
made keybindings general

### DIFF
--- a/src/modes/keybindings.cc
+++ b/src/modes/keybindings.cc
@@ -122,6 +122,10 @@ namespace Astroid {
             UstringUtils::trim (target);
 
             Key k (keyspec);
+            if (k.key == GDK_KEY_VoidSymbol) {
+              LOG (error) << "ky: user bindings: invalid key name: " << spec;
+              continue;
+            }
 
             LOG (debug) << "ky: run: " << name << "(" << k.str () << "): " << target;
 
@@ -553,7 +557,7 @@ namespace Astroid {
     } else {
       /* check if key is in map */
       UstringUtils::trim (k);
-      const char *k_str = k.c_str ();
+      const char * k_str = k.c_str ();
       guint kk = gdk_keyval_from_name (k_str);
 
       return kk;
@@ -674,11 +678,12 @@ namespace Astroid {
     if (isgraph (k)) {
       s += k;
     } else {
-      try {
-        ustring kk = gdk_keyval_name (key);
-        s += kk;
-      } catch (std::exception &ex) {
-        s += ustring::compose ("%1", key);
+      gchar * c = gdk_keyval_name (key);
+      if (c == NULL) {
+        LOG (error) << "invalid key: " << key << " for: " << name;
+        throw keyspec_error ("invalid key");
+      } else {
+        s += ustring (c);
       }
     }
 

--- a/src/modes/keybindings.cc
+++ b/src/modes/keybindings.cc
@@ -574,7 +574,8 @@ namespace Astroid {
     } else {
       /* check if key is in map */
       UstringUtils::trim (k);
-      guint kk = Keybindings::keynames_to_keyval.at (k);
+      const char *k_str = k.c_str ();
+      guint kk = gdk_keyval_from_name (k_str);
 
       return kk;
     }
@@ -695,7 +696,7 @@ namespace Astroid {
       s += k;
     } else {
       try {
-        ustring kk = Keybindings::keyval_to_keynames.at (key);
+        ustring kk = gdk_keyval_name (key);
         s += kk;
       } catch (std::exception &ex) {
         s += ustring::compose ("%1", key);

--- a/src/modes/keybindings.cc
+++ b/src/modes/keybindings.cc
@@ -19,32 +19,7 @@ namespace Astroid {
   std::vector<Key>  Keybindings::user_bindings;
   std::vector<std::pair<Key, ustring>> Keybindings::user_run_bindings;
 
-  std::map<guint, ustring> Keybindings::keyval_to_keynames = {
-    { GDK_KEY_Down,   "Down" },
-    { GDK_KEY_Up,     "Up" },
-    { GDK_KEY_Tab,    "Tab" },
-    { GDK_KEY_ISO_Left_Tab, "ISO_Left_Tab" },
-    { GDK_KEY_Home,   "Home" },
-    { GDK_KEY_End,    "End" },
-    { GDK_KEY_Return, "Return" },
-    { GDK_KEY_KP_Enter, "KP_Enter" },
-    { GDK_KEY_Page_Up, "Page_Up" },
-    { GDK_KEY_Page_Down, "Page_Down" },
-    { GDK_KEY_Escape, "Esc" },
-    { GDK_KEY_equal, "Equal" },
-    { GDK_KEY_minus, "Minus" },
-    { GDK_KEY_space, "Space" },
-  };
-
-  std::map<ustring, guint> Keybindings::keynames_to_keyval;
-
   void Keybindings::init () {
-    /* build keynames_to_keyval */
-    keynames_to_keyval.clear ();
-    for (auto &s : keyval_to_keynames) {
-      keynames_to_keyval.insert (std::make_pair (s.second, s.first));
-    }
-
     if (!user_bindings_loaded) {
       user_bindings_loaded = true;
 

--- a/src/modes/keybindings.cc
+++ b/src/modes/keybindings.cc
@@ -157,6 +157,10 @@ namespace Astroid {
             k = UnboundKey ();
           } else {
             k = Key (spec);
+            if (k.key == GDK_KEY_VoidSymbol) {
+              LOG (error) << "ky: user bindings: invalid key name: " << spec;
+              continue;
+            }
           }
 
           k.name = parts[0];

--- a/src/modes/keybindings.hh
+++ b/src/modes/keybindings.hh
@@ -119,10 +119,6 @@ namespace Astroid {
 
       static std::atomic<bool> user_bindings_loaded;
       static const char * user_bindings_file;
-
-    public:
-      static std::map<guint, ustring> keyval_to_keynames;
-      static std::map<ustring, guint> keynames_to_keyval;
   };
 }
 


### PR DESCRIPTION
I changed the kludgy list of keynames_to_keyval for the general gdk function gdk_keyval_from_name and gdk_keyval_name.

For some reason I'm having trouble compiling master, but I've tested the changes with v0.6 and they work. Can someone else test with master? If the changes work, it may be possible to remove keynames_to_keyvals altogether, but I wasn't sure if other things were relying on it.
solves issue #212 