### PR TITLE
added ENV=os.environ, which allows it to compile on NixOS

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -5,7 +5,7 @@ from subprocess import *
 def getGitDesc():
   return Popen('git describe --abbrev=8 --tags --always', stdout=PIPE, shell=True).stdout.read ().strip ()
 
-env = Environment ()
+env = Environment (ENV=os.environ)
 
 AddOption ("--release", action="store", dest="release", default="git", help="Make a release (default: git describe output)")
 AddOption ("--enable-debug", action="store", dest="debug", default=None, help="Enable the -g flag for debugging (default: true when release is git)")


### PR DESCRIPTION
I made a change to the SConstruct file which allows it to find the libraries it needs by looking in the user-supplied environment variables instead of hardcoded ones.
