### PR TITLE
Polling issue patch

### DIFF
--- a/src/modes/log_view.cc
+++ b/src/modes/log_view.cc
@@ -184,7 +184,7 @@ namespace Astroid {
 
     auto lvl = rec[logging::trivial::severity];
 
-    auto ts  = rec["TimeStamp"].extract<boost::posix_time::ptime> ();
+    auto ts  = logging::extract<boost::posix_time::ptime> ("TimeStamp",rec);
     boost::posix_time::time_facet * f = new boost::posix_time::time_facet ("%H:%M:%S.%f");
 
     std::ostringstream s;

--- a/src/poll.cc
+++ b/src/poll.cc
@@ -17,6 +17,8 @@ using namespace boost::filesystem;
 
 namespace Astroid {
   const int Poll::DEFAULT_POLL_INTERVAL = 60;
+  sigc::connection debug;
+  sigc::connection warn;
 
   Poll::Poll (bool _auto_polling_enabled) {
     LOG (info) << "poll: setting up.";
@@ -132,8 +134,8 @@ namespace Astroid {
     }
 
     /* connect channels */
-    Glib::signal_io().connect (sigc::mem_fun (this, &Poll::log_out), stdout, Glib::IO_IN | Glib::IO_HUP);
-    Glib::signal_io().connect (sigc::mem_fun (this, &Poll::log_err), stderr, Glib::IO_IN | Glib::IO_HUP);
+    warn = Glib::signal_io().connect (sigc::mem_fun (this, &Poll::log_out), stdout, Glib::IO_IN | Glib::IO_HUP);
+    debug = Glib::signal_io().connect (sigc::mem_fun (this, &Poll::log_err), stderr, Glib::IO_IN | Glib::IO_HUP);
     Glib::signal_child_watch().connect (sigc::mem_fun (this, &Poll::child_watch), pid);
 
     ch_stdout = Glib::IOChannel::create_from_fd (stdout);
@@ -260,6 +262,8 @@ namespace Astroid {
 # endif
     }
 
+    warn.disconnect();
+    debug.disconnect();
     m_dopoll.unlock ();
   }
 


### PR DESCRIPTION
This stops the polling logger to loop endlessly after the poll.sh script finishes