### PR TITLE
In some cases notmuch_thread_get_toplevel_messages and notmuch_messa…

### DIFF
--- a/src/message_thread.cc
+++ b/src/message_thread.cc
@@ -803,6 +803,39 @@ namespace Astroid {
           add_replies (message, level + 1);
 
         }
+
+        if (messages.size() != (unsigned int) notmuch_thread_get_total_messages (nm_thread))
+        {
+          ustring mid;
+          LOG (error) << "message: thread count not met! Brute force!";
+          for (qmessages = notmuch_thread_get_messages (nm_thread);
+               notmuch_messages_valid (qmessages);
+               notmuch_messages_move_to_next (qmessages)) {
+            bool found;
+            found = false;
+
+            message = notmuch_messages_get (qmessages);
+            
+            mid = notmuch_message_get_message_id (message);
+            LOG (error) << "mid: " << mid;
+
+            for (unsigned int i = 0; i < messages.size(); i ++)
+            {
+              if (messages[i]->mid == mid)
+              {
+                found = true;
+                break;
+              }
+            }
+            if ( ! found )
+            {
+              LOG (error) << "mid: " << mid << " was missing!";
+              messages.push_back (refptr<Message>(new Message (message, level)));
+            }
+          }
+
+        }
+
       });
   }
 


### PR DESCRIPTION
…ge_get_replies don't return all the messages in a thread. Lets still load those messages.

I've encountered a weird scenario where I couldn't load some messages in a thread. It appears that the notmuch_thread_get_toplevel_messages and notmuch_message_get_replies don't always return all the messages in a thread.