### PR TITLE
sass: set options directly on file_ctx to avoid options reset

### DIFF
--- a/src/modes/thread_view/theme.cc
+++ b/src/modes/thread_view/theme.cc
@@ -107,8 +107,6 @@ namespace Astroid {
     sass_option_set_precision(options, 1);
     sass_option_set_source_comments(options, true);
 
-    sass_file_context_set_options(file_ctx, options);
-
     int status = sass_compile_file_context (file_ctx);
 
     if (status != 0) {


### PR DESCRIPTION
recent libsass (3.4) resets the original context when setting an option
(https://github.com/sass/libsass/issues/2257) causing the input_path to
be lost (#244). here we set the options directly on file_ctx which is a
subclass of options - this might break in the future if file_ctx no
longer sub-classes options. oh well.