### PR TITLE
hint: how to cancel when the message is being sent

### DIFF
--- a/src/compose_message.cc
+++ b/src/compose_message.cc
@@ -371,7 +371,7 @@ namespace Astroid {
 
     if (cancel_send_during_delay) {
       LOG (error) << "cm: cancelled sending before message could be sent.";
-      message_send_status_msg = "sending message.. cancelled before sending.";
+      message_send_status_msg = "sending message... cancelled before sending.";
       message_send_status_warn = true;
       d_message_send_status ();
 
@@ -383,7 +383,7 @@ namespace Astroid {
 
     lk.unlock ();
 
-    message_send_status_msg = "sending message..";
+    message_send_status_msg = "sending message... Press C-c to cancel!"; /*fixme replace C-c with the actual keybding configured by the user*/
     d_message_send_status ();
 
     /* Send the message */

--- a/src/compose_message.cc
+++ b/src/compose_message.cc
@@ -362,7 +362,11 @@ namespace Astroid {
 
     while (delay > 0 && !cancel_send_during_delay) {
       LOG (debug) << "cm: sending in " << delay << " seconds..";
-      message_send_status_msg = ustring::compose ("sending message in %1 seconds... Press C-c to cancel!", delay); /*fixme replace C-c with the actual keybding configured by the user*/
+        if (astroid->hint_level () < 1) {
+          message_send_status_msg = ustring::compose ("sending message in %1 seconds... Press C-c to cancel!", delay); /*fixme replace C-c with the actual keybding configured by the user*/
+	} else {
+          message_send_status_msg = ustring::compose ("sending message in %1 seconds...", delay);
+	}
       d_message_send_status ();
       std::chrono::seconds sec (1);
       send_cancel_cv.wait_until (lk, std::chrono::system_clock::now () + sec, [&] { return cancel_send_during_delay; });
@@ -383,7 +387,11 @@ namespace Astroid {
 
     lk.unlock ();
 
-    message_send_status_msg = "sending message... Press C-c to cancel!"; /*fixme replace C-c with the actual keybding configured by the user*/
+    if (astroid->hint_level () < 1) {
+      message_send_status_msg = "sending message... Press C-c to cancel!"; /*fixme replace C-c with the actual keybding configured by the user*/
+    } else {
+      message_send_status_msg = "sending message...";
+    }
     d_message_send_status ();
 
     /* Send the message */

--- a/src/compose_message.cc
+++ b/src/compose_message.cc
@@ -362,7 +362,7 @@ namespace Astroid {
 
     while (delay > 0 && !cancel_send_during_delay) {
       LOG (debug) << "cm: sending in " << delay << " seconds..";
-      message_send_status_msg = ustring::compose ("sending message in %1 seconds..", delay);
+      message_send_status_msg = ustring::compose ("sending message in %1 seconds... Press C-c to cancel!", delay); /*fixme replace C-c with the actual keybding configured by the user*/
       d_message_send_status ();
       std::chrono::seconds sec (1);
       send_cancel_cv.wait_until (lk, std::chrono::system_clock::now () + sec, [&] { return cancel_send_during_delay; });


### PR DESCRIPTION
I need to figure out where to get the variable to display the Cancel keybinding.

Also, maybe the "hint" could be hidden if the user has configured for less hints.