### PR TITLE
poll, astroid: add --start-polling and --stop-polling to indicate ext…

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -22,6 +22,9 @@
 * Delay sending of message with configured time, in order to be able to
   cancel wrongly sent messages.
 
+* New --start-polling, --stop-polling and --refresh LASTMOD options which
+  makes external polling mechanisms work better.
+
 == v0.7 / 2017-01-02
 
 * Messages are marked unread after a delay (default 2 sec) in

--- a/src/astroid.cc
+++ b/src/astroid.cc
@@ -120,6 +120,7 @@ namespace Astroid {
       ( "append-log,a", "append to log file")
       ( "start-polling", "indicate that external polling (external notmuch db R/W operations) starts")
       ( "stop-polling", "indicate that external polling stops")
+      ( "refresh", po::value<unsigned long>(), "refresh threads changed since lastmod")
 # ifndef DISABLE_PLUGINS
       ( "disable-plugins", "disable plugins");
 # else
@@ -247,8 +248,8 @@ namespace Astroid {
         }
       }
 
-      if (vm.count("start-polling") || vm.count("stop-polling")) {
-        LOG (error) << "--start-polling or --stop-polling can only be specifed when there is already a running astroid instance.";
+      if (vm.count("start-polling") || vm.count("stop-polling") || vm.count ("refresh")) {
+        LOG (error) << "--start-polling, --stop-polling or --refresh can only be specifed when there is already a running astroid instance.";
         exit (1);
       }
 
@@ -401,19 +402,24 @@ namespace Astroid {
         new_window = false;
       }
 
-      if (vm.count ("start-polling")) {
-        if (vm.count ("stop-polling")) {
-          LOG (error) << "--start-polling specified together with --stop-polling";
+      if ((vm.count ("start-polling") ? 1:0) + (vm.count ("stop-polling") ? 1:0) + (vm.count("refresh") ? 1:0) > 1) {
+          LOG (error) << "only one of --start-polling, --stop-polling and --refresh should be specified";
           return 1;
-        }
+      }
+
+      if (vm.count ("start-polling")) {
 
         poll->start_polling ();
         new_window = false;
 
       } else if (vm.count ("stop-polling")) {
-        /* conflicting args check covered by above case */
 
         poll->stop_polling ();
+        new_window = false;
+
+      } else if (vm.count ("refresh")) {
+        unsigned long last = vm["refresh"].as<unsigned long> ();
+        poll->refresh ( last );
         new_window = false;
       }
     }

--- a/src/astroid.cc
+++ b/src/astroid.cc
@@ -118,6 +118,8 @@ namespace Astroid {
       ( "no-auto-poll", "do not poll automatically")
       ( "log,l", po::value<ustring>(), "log to file")
       ( "append-log,a", "append to log file")
+      ( "start-polling", "indicate that external polling (external notmuch db R/W operations) starts")
+      ( "stop-polling", "indicate that external polling stops")
 # ifndef DISABLE_PLUGINS
       ( "disable-plugins", "disable plugins");
 # else
@@ -243,6 +245,11 @@ namespace Astroid {
         } else {
           m_config = new Config ();
         }
+      }
+
+      if (vm.count("start-polling") || vm.count("stop-polling")) {
+        LOG (error) << "--start-polling or --stop-polling can only be specifed when there is already a running astroid instance.";
+        exit (1);
       }
 
       _hint_level = config ("astroid.hints").get<int> ("level");
@@ -391,6 +398,22 @@ namespace Astroid {
       if (vm.count("mailto")) {
         ustring mailtourl = vm["mailto"].as<ustring>();
         send_mailto (mailtourl);
+        new_window = false;
+      }
+
+      if (vm.count ("start-polling")) {
+        if (vm.count ("stop-polling")) {
+          LOG (error) << "--start-polling specified together with --stop-polling";
+          return 1;
+        }
+
+        poll->start_polling ();
+        new_window = false;
+
+      } else if (vm.count ("stop-polling")) {
+        /* conflicting args check covered by above case */
+
+        poll->stop_polling ();
         new_window = false;
       }
     }

--- a/src/poll.hh
+++ b/src/poll.hh
@@ -18,11 +18,15 @@ namespace Astroid {
       const char * poll_script = "poll.sh";
       static const int DEFAULT_POLL_INTERVAL; // 60
 
+      void start_polling ();
+      void stop_polling ();
+
     private:
       std::mutex m_dopoll;
 
       int poll_interval = 0;
       bool auto_polling_enabled = true;
+      bool external_polling = false;
 
       void do_poll ();
       bool periodic_polling ();
@@ -34,6 +38,7 @@ namespace Astroid {
       unsigned long last_good_before_poll_revision = 0;
       unsigned long before_poll_revision = 0;
 # endif
+      void refresh_threads ();
 
       int pid;
       int stdin;

--- a/src/poll.hh
+++ b/src/poll.hh
@@ -20,6 +20,7 @@ namespace Astroid {
 
       void start_polling ();
       void stop_polling ();
+      void refresh (unsigned long before);
 
     private:
       std::mutex m_dopoll;
@@ -35,7 +36,6 @@ namespace Astroid {
       std::chrono::time_point<std::chrono::steady_clock> last_poll;
 
 # ifdef HAVE_NOTMUCH_GET_REV
-      unsigned long last_good_before_poll_revision = 0;
       unsigned long before_poll_revision = 0;
 # endif
       void refresh_threads ();


### PR DESCRIPTION
…ernal polling

See #64, #275, #302. This adds the --start-polling and --stop-polling flags to
astroid which indicates that there is an external polling operation
going on. This starts the spinner, prevents internal polling,
and refreshes any threads that have been changed since --start-polling
when --stop-polling is called.

It is the users responsibility to make sure to call --stop-polling after
having called --start-polling, even if the polling operation fails.