### PR TITLE
Multiple UI errors caused by missing shared files

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -509,7 +509,7 @@ inst_shr = env.Install (idir_ui,  Glob ('ui/*.glade') +
                                   Glob ('ui/*.html'))
 
 # icons are installed in two locations
-inst_shr = env.Install (os.path.join(idir_ui, 'icons'),  Glob ('ui/icons/*'))
+inst_shr += env.Install (os.path.join(idir_ui, 'icons'),  Glob ('ui/icons/*'))
 
 inst_shr += env.InstallAs (os.path.join (idir_icon, '512x512/apps/astroid.png'), 'ui/icons/icon_color.png')
 inst_shr += env.InstallAs (os.path.join (idir_icon, 'scalable/apps/astroid.svg'), 'ui/icons/icon_color.svg')


### PR DESCRIPTION
This line should _extend_ the current definition of inst_shr, not replace it.

There are two main user symptoms of this: the "New Message" tab is completely
blank (I guess there is no HTML for it to render), and the "no-mail.png" icon
is missing, which sometimes makes the program fail on startup.