### PR TITLE
Escaping . characters for CSS auto-tag-classes

### DIFF
--- a/src/modes/thread_view/thread_view.cc
+++ b/src/modes/thread_view/thread_view.cc
@@ -645,6 +645,7 @@ namespace Astroid {
 
     for (ustring t : m->tags) {
       t = UstringUtils::replace (t, "/", "-");
+      t = UstringUtils::replace (t, ".", "-");
       t = Glib::Markup::escape_text (t);
 
       t = "nm-" + t;


### PR DESCRIPTION
Extending the escaping mechanism from https://github.com/astroidmail/astroid/commit/0ff5fe1a70558c9f61001e9734e42d9df608f3d6 for people using periods in their notmuch tags.