### PR TITLE
compose: skip empty references/in-reply-to

### DIFF
--- a/src/compose_message.cc
+++ b/src/compose_message.cc
@@ -83,14 +83,24 @@ namespace Astroid {
 
   void ComposeMessage::set_references (ustring _refs) {
     references = _refs;
-    g_mime_object_set_header (GMIME_OBJECT(message), "References",
-        references.c_str());
+    if (references.empty ())
+        g_mime_header_list_remove (
+            g_mime_object_get_header_list (GMIME_OBJECT(message)),
+            "References");
+    else
+        g_mime_object_set_header (GMIME_OBJECT(message), "References",
+            references.c_str());
   }
 
   void ComposeMessage::set_inreplyto (ustring _inreplyto) {
     inreplyto = _inreplyto;
-    g_mime_object_set_header (GMIME_OBJECT(message), "In-Reply-To",
-        inreplyto.c_str());
+    if (inreplyto.empty ())
+        g_mime_header_list_remove (
+            g_mime_object_get_header_list (GMIME_OBJECT(message)),
+            "In-Reply-To");
+    else
+        g_mime_object_set_header (GMIME_OBJECT(message), "In-Reply-To",
+            inreplyto.c_str());
   }
 
   void ComposeMessage::build () {

--- a/test/test_composed_message.cc
+++ b/test/test_composed_message.cc
@@ -51,5 +51,25 @@ BOOST_AUTO_TEST_SUITE(Composing)
 
   }
 
+  BOOST_AUTO_TEST_CASE (compose_test_references)
+  {
+    using Astroid::ComposeMessage;
+    using Astroid::Message;
+    setup ();
+
+    ComposeMessage * c = new ComposeMessage ();
+    ustring ref = "test-ref";
+
+    c->set_references (ref);
+
+    BOOST_CHECK_MESSAGE (ref == g_mime_object_get_header (GMIME_OBJECT(c->message), "References"), "message references is set");
+
+    c->set_references ("");
+
+    BOOST_CHECK_MESSAGE (FALSE == g_mime_header_list_contains (g_mime_object_get_header_list (GMIME_OBJECT(c->message)), "References"), "message references is set when empty");
+
+    teardown ();
+  }
+
 BOOST_AUTO_TEST_SUITE_END()
 


### PR DESCRIPTION
This change avoid empty References/In-Reply-To header on new sent mail.