### PR TITLE
poll: keep sigc::connection in poll thread, don't connect unused stdin

### DIFF
--- a/src/poll.cc
+++ b/src/poll.cc
@@ -228,6 +228,26 @@ namespace Astroid {
     c_ch_stderr.disconnect();
     c_ch_stdout.disconnect();
 
+    if (ch_stdout) {
+      Glib::ustring buf;
+
+      ch_stdout->read_to_end (buf);
+      if (*(--buf.end()) == '\n') buf.erase (--buf.end());
+
+      if (!buf.empty ()) LOG (debug) << "poll script: " << buf;
+      ch_stdout.clear ();
+    }
+
+    if (ch_stderr) {
+      Glib::ustring buf;
+
+      ch_stderr->read_to_end (buf);
+      if (*(--buf.end()) == '\n') buf.erase (--buf.end());
+
+      if (!buf.empty ()) LOG (warn) << "poll script: " << buf;
+      ch_stderr.clear ();
+    }
+
     ::close (stdout);
     ::close (stderr);
 
@@ -250,6 +270,7 @@ namespace Astroid {
   bool Poll::log_out (Glib::IOCondition cond) {
     if (cond == Glib::IO_HUP) {
       ch_stdout.clear();
+      LOG (debug) << "poll: (stdout) got HUP";
       return false;
     }
 
@@ -270,6 +291,7 @@ namespace Astroid {
   bool Poll::log_err (Glib::IOCondition cond) {
     if (cond == Glib::IO_HUP) {
       ch_stderr.clear();
+      LOG (debug) << "poll: (stderr) got HUP";
       return false;
     }
 

--- a/src/poll.cc
+++ b/src/poll.cc
@@ -195,7 +195,7 @@ namespace Astroid {
                         Glib::SPAWN_DO_NOT_REAP_CHILD,
                         sigc::slot <void> (),
                         &pid,
-                        &stdin,
+                        NULL,
                         &stdout,
                         &stderr
                         );
@@ -214,11 +214,11 @@ namespace Astroid {
     lk.unlock ();
 
     /* connect channels */
-    c_ch_stdout = Glib::signal_io().connect (sigc::mem_fun (this, &Poll::log_out), stdout, Glib::IO_IN | Glib::IO_HUP);
-    c_ch_stderr = Glib::signal_io().connect (sigc::mem_fun (this, &Poll::log_err), stderr, Glib::IO_IN | Glib::IO_HUP);
-
     ch_stdout = Glib::IOChannel::create_from_fd (stdout);
     ch_stderr = Glib::IOChannel::create_from_fd (stderr);
+
+    sigc::connection c_ch_stdout = Glib::signal_io().connect (sigc::mem_fun (this, &Poll::log_out), stdout, Glib::IO_IN | Glib::IO_HUP);
+    sigc::connection c_ch_stderr = Glib::signal_io().connect (sigc::mem_fun (this, &Poll::log_err), stderr, Glib::IO_IN | Glib::IO_HUP);
 
     /* wait for poll to finish */
     int status;
@@ -228,7 +228,6 @@ namespace Astroid {
     c_ch_stderr.disconnect();
     c_ch_stdout.disconnect();
 
-    ::close (stdin);
     ::close (stdout);
     ::close (stderr);
 

--- a/src/poll.hh
+++ b/src/poll.hh
@@ -47,15 +47,11 @@ namespace Astroid {
       std::condition_variable poll_cancel_cv;
 
       GPid pid;
-      int stdin;
       int stdout;
       int stderr;
       refptr<Glib::IOChannel> ch_stdout;
       refptr<Glib::IOChannel> ch_stderr;
-      sigc::connection c_ch_stdout;
-      sigc::connection c_ch_stderr;
       Glib::Dispatcher d_refresh;
-
 
       bool log_out (Glib::IOCondition);
       bool log_err (Glib::IOCondition);


### PR DESCRIPTION
Attempt to fix #335.