### PR TITLE
cb: do not use ',' to delimit tags, only space

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -2,6 +2,10 @@
 
 * Attach messages by mids with 'A' in new emails.
 
+* Colorful tags in tag editor and in searching
+
+* Tags in the tag editor is now separated by spaces (comma still works)
+
 == v0.9.1 / 2017-04-30
 
 * Support old vte3.

--- a/src/command_bar.cc
+++ b/src/command_bar.cc
@@ -401,7 +401,7 @@ namespace Astroid {
     }
   }
 
-  /* searches backwards to the previous ',' and extracts the
+  /* searches backwards to the previous ' ' and extracts the
    * part of the partially entered tag to be matched on.
    */
   ustring CommandBar::TagCompletion::get_partial_tag (ustring_sz &outpos) {

--- a/src/modes/thread_index/thread_index_list_view.cc
+++ b/src/modes/thread_index/thread_index_list_view.cc
@@ -925,14 +925,14 @@ namespace Astroid {
         [&] (Key) {
           auto thread = get_current_thread ();
           if (thread) {
-            ustring tag_list = VectorUtils::concat_tags (thread->tags) + ", ";
+            ustring tag_list = VectorUtils::concat_tags (thread->tags) + " ";
 
             main_window->enable_command (CommandBar::CommandMode::Tag,
                 tag_list,
                 [&,thread](ustring tgs) {
                   LOG (debug) << "ti: got tags: " << tgs;
 
-                  vector<ustring> tags = VectorUtils::split_and_trim (tgs, ",");
+                  vector<ustring> tags = VectorUtils::split_and_trim (tgs, ",| ");
 
                   /* remove empty */
                   tags.erase (std::remove (tags.begin (), tags.end (), ""), tags.end ());

--- a/src/modes/thread_view/thread_view.cc
+++ b/src/modes/thread_view/thread_view.cc
@@ -2944,7 +2944,7 @@ namespace Astroid {
             return false;
           }
 
-          ustring tag_list = VectorUtils::concat_tags (focused_message->tags) + ", ";
+          ustring tag_list = VectorUtils::concat_tags (focused_message->tags) + " ";
 
           main_window->enable_command (CommandBar::CommandMode::Tag,
               "Change tags for message:",
@@ -2952,7 +2952,7 @@ namespace Astroid {
               [&](ustring tgs) {
                 LOG (debug) << "ti: got tags: " << tgs;
 
-                vector<ustring> tags = VectorUtils::split_and_trim (tgs, ",");
+                vector<ustring> tags = VectorUtils::split_and_trim (tgs, ",| ");
 
                 /* remove empty */
                 tags.erase (std::remove (tags.begin (), tags.end (), ""), tags.end ());

--- a/src/utils/vector_utils.cc
+++ b/src/utils/vector_utils.cc
@@ -58,7 +58,7 @@ namespace Astroid {
   }
 
   ustring VectorUtils::concat_tags (vector<ustring> tags) {
-    return concat (tags, ", ", stop_ons_tags);
+    return concat (tags, " ", stop_ons_tags);
   }
 
   ustring VectorUtils::concat_tags_color (


### PR DESCRIPTION
Skip the ',' as delimiter for tags. This makes it quicker to navigate and edit tags. Tags with spaces in them are not supported, but I dont think they were in the first place either. Opinions?