### PR TITLE
Introduce signature_separate config option

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -6,6 +6,9 @@
 
 * Tags in the tag editor is now separated by spaces (comma still works)
 
+* configuration option signature_separate determines if signatures
+  will be separated from the message by a line containing '-- '.
+
 == v0.9.1 / 2017-04-30
 
 * Support old vte3.

--- a/src/account_manager.cc
+++ b/src/account_manager.cc
@@ -39,6 +39,7 @@ namespace Astroid {
 
       a->save_drafts_to = kv.second.get<string> ("save_drafts_to");
 
+      a->signature_separate = kv.second.get<bool> ("signature_separate");
       a->signature_file = kv.second.get<string> ("signature_file");
       a->signature_default_on = kv.second.get<bool> ("signature_default_on");
       a->signature_attach     = kv.second.get<bool> ("signature_attach");

--- a/src/account_manager.hh
+++ b/src/account_manager.hh
@@ -24,6 +24,7 @@ namespace Astroid {
       std::vector<ustring> additional_sent_tags;
       ustring save_drafts_to;
 
+      bool      signature_separate = false;
       bfs::path signature_file;
       bool      signature_default_on;
       bool      signature_attach;

--- a/src/compose_message.cc
+++ b/src/compose_message.cc
@@ -117,6 +117,9 @@ namespace Astroid {
       std::ostringstream sf;
       sf << s.rdbuf ();
       s.close ();
+      if (account->signature_separate) {
+	body_content += "-- \n";
+      }
       body_content += sf.str ();
     }
 

--- a/src/config.cc
+++ b/src/config.cc
@@ -146,6 +146,7 @@ namespace Astroid {
       default_config.put ("accounts.charlie.save_drafts_to",
           "/home/root/Mail/drafts/");
 
+      default_config.put ("accounts.charlie.signature_separate", false);
       default_config.put ("accounts.charlie.signature_file", "");
       default_config.put ("accounts.charlie.signature_default_on", true);
       default_config.put ("accounts.charlie.signature_attach", false);
@@ -391,7 +392,7 @@ namespace Astroid {
       LOG (warn) << "config: astroid now reads standard notmuch options from notmuch config, it is configured through: 'astroid.notmuch_config' and is now set to the default: ~/.notmuch-config. please validate!";
     }
 
-    if (version < 6) {
+    if (version < 8) {
       /* check accounts signature */
       ptree apt = config.get_child ("accounts");
 
@@ -436,6 +437,19 @@ namespace Astroid {
           } catch (const boost::property_tree::ptree_bad_path &ex) {
 
             ustring key = ustring::compose ("accounts.%1.always_gpg_sign", kv.first);
+            config.put (key.c_str (), false);
+          }
+        }
+
+        if (version < 8) {
+          LOG (debug) << "Trying upgrade for signature separate. Version:" << version;
+          try {
+            
+            ustring ss = kv.second.get<string> ("signature_separate");
+            
+          } catch (const boost::property_tree::ptree_bad_path &ex) {
+            
+            ustring key = ustring::compose ("accounts.%1.signature_separate", kv.first);
             config.put (key.c_str (), false);
           }
         }

--- a/src/config.hh
+++ b/src/config.hh
@@ -56,7 +56,7 @@ namespace Astroid {
       ptree config;
       ptree notmuch_config;
 
-      const int CONFIG_VERSION = 7;
+      const int CONFIG_VERSION = 8;
 
     private:
       ptree setup_default_config (bool);


### PR DESCRIPTION
When true, the signature part of the message will be separated from
the message by '-- \n'

Related issue #371 