### PR TITLE
Locations to bfs::path and expand '~' consistency

### DIFF
--- a/src/account_manager.cc
+++ b/src/account_manager.cc
@@ -10,6 +10,7 @@
 # include "config.hh"
 # include "utils/ustring_utils.hh"
 # include "utils/vector_utils.hh"
+# include "utils/utils.hh"
 
 using namespace std;
 using boost::property_tree::ptree;
@@ -32,15 +33,15 @@ namespace Astroid {
       a->isdefault = kv.second.get<bool> ("default");
 
       a->save_sent = kv.second.get<bool> ("save_sent");
-      a->save_sent_to = kv.second.get<string> ("save_sent_to");
+      a->save_sent_to = Utils::expand(bfs::path (kv.second.get<string> ("save_sent_to")));
       ustring sent_tags_s = kv.second.get<string> ("additional_sent_tags");
       a->additional_sent_tags = VectorUtils::split_and_trim (sent_tags_s, ",");
       sort (a->additional_sent_tags.begin (), a->additional_sent_tags.end ());
 
-      a->save_drafts_to = kv.second.get<string> ("save_drafts_to");
+      a->save_drafts_to = Utils::expand(bfs::path (kv.second.get<string> ("save_drafts_to")));
 
       a->signature_separate = kv.second.get<bool> ("signature_separate");
-      a->signature_file = kv.second.get<string> ("signature_file");
+      a->signature_file = Utils::expand(bfs::path (kv.second.get<string> ("signature_file")));
       a->signature_default_on = kv.second.get<bool> ("signature_default_on");
       a->signature_attach     = kv.second.get<bool> ("signature_attach");
 

--- a/src/account_manager.hh
+++ b/src/account_manager.hh
@@ -20,9 +20,9 @@ namespace Astroid {
       bool isdefault;
 
       bool save_sent;
-      ustring save_sent_to;
+      bfs::path save_sent_to;
       std::vector<ustring> additional_sent_tags;
-      ustring save_drafts_to;
+      bfs::path save_drafts_to;
 
       bool      signature_separate = false;
       bfs::path signature_file;

--- a/src/compose_message.cc
+++ b/src/compose_message.cc
@@ -503,7 +503,7 @@ namespace Astroid {
 
         if (account->save_sent) {
           using bfs::path;
-          save_to = path(account->save_sent_to) / path(id + ":2,");
+          save_to = account->save_sent_to / path(id + ":2,");
           LOG (info) << "cm: saving message to: " << save_to;
 
           write (save_to.c_str());

--- a/src/modes/edit_message.cc
+++ b/src/modes/edit_message.cc
@@ -566,7 +566,7 @@ namespace Astroid {
     if (!draft_msg) {
       /* make new message */
 
-      path ddir = path(c->account->save_drafts_to.c_str ());
+      path ddir = c->account->save_drafts_to;
       if (!is_directory(ddir)) {
         LOG (error) << "em: no draft directory specified!";
         set_warning ("draft could not be saved, no suitable draft directory for account specified.");


### PR DESCRIPTION
- save_sent_to : make bfs::path, adjust related and expand '~'
- save_drafts_to  : make bfs::path, adjust related and expand '~'
- signature_file : expand '~'