### PR TITLE
Improve 'c' (compose to sender) command

### DIFF
--- a/src/modes/edit_message.cc
+++ b/src/modes/edit_message.cc
@@ -34,12 +34,13 @@ using namespace boost::filesystem;
 namespace Astroid {
   int EditMessage::edit_id = 0;
 
-  EditMessage::EditMessage (MainWindow * mw, ustring _to, ustring _from) :
+  EditMessage::EditMessage (MainWindow * mw, ustring _to, ustring _from, ustring _cc, ustring _bcc) :
     EditMessage (mw, false) { // {{{
 
     in_read = false;
-    to = _to;
-
+    to  = _to;
+    cc  = _cc;
+    bcc = _bcc;
     if (!_from.empty ()) {
       set_from (Address (_from));
     }

--- a/src/modes/edit_message.hh
+++ b/src/modes/edit_message.hh
@@ -31,7 +31,7 @@ namespace Astroid {
 
     public:
       EditMessage (MainWindow *, bool edit_when_ready = true);
-      EditMessage (MainWindow *, ustring to, ustring from = "");
+      EditMessage (MainWindow *, ustring to, ustring from = "", ustring cc = "", ustring bcc = "");
       EditMessage (MainWindow *, refptr<Message> _msg);
       ~EditMessage ();
 


### PR DESCRIPTION
Initial resolve for issue #381  but probably needs a bit more, please
review.

- clarify help text for command
- support cc and bcc in recipient when composing to self
  (bcc is probably not that useful here)
- adjust variable naming to clarify code

Added `EditMessage` with additional signature, probably a bit
overkill and could use just the one.