### PR TITLE
Fix macOS Build

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -318,12 +318,12 @@ if not conf.CheckLib ('boost_date_time', language = 'c++'):
 
 libs   = ['notmuch',
           'boost_filesystem',
-          'boost_system',
           'boost_program_options',
           'boost_log_setup',
-          'boost_log',
-          'boost_thread',
+          'boost_log-mt',
+          'boost_thread-mt',
           'boost_date_time',
+          'boost_system-mt',
           'stdc++']
 
 env.AppendUnique (LIBS = libs)

--- a/SConstruct
+++ b/SConstruct
@@ -320,10 +320,10 @@ libs   = ['notmuch',
           'boost_filesystem',
           'boost_program_options',
           'boost_log_setup',
-          'boost_log-mt',
-          'boost_thread-mt',
+          'boost_log',
+          'boost_thread',
           'boost_date_time',
-          'boost_system-mt',
+          'boost_system',
           'stdc++']
 
 env.AppendUnique (LIBS = libs)

--- a/src/utils/compiler.h
+++ b/src/utils/compiler.h
@@ -2,10 +2,28 @@
 
 # if defined (__clang__)
 
-# if __has_attribute(clang::fallthrough)
-# define FALLTHROUGH [[clang::fallthrough]]
+# ifndef __has_attribute
+#   define __has_attribute(x) 0
+# endif
+# ifndef __has_cpp_attribute
+#   define __has_cpp_attribute(x) 0
+# endif
+# ifndef __has_builtin
+#   define __has_builtin(x) 0
+# endif
+# ifndef __has_feature
+#   define __has_feature(x) 0
+# endif
+# ifndef __has_extension
+#   define __has_extension(x) 0
+# endif
+# ifndef __has_warning
+#   define __has_warning(x) 0
+# endif
+# if __has_cpp_attribute(clang::fallthrough)
+#   define FALLTHROUGH [[clang::fallthrough]]
 # else
-# define FALLTHROUGH
+#   define FALLTHROUGH
 # endif
 
 # elif defined (__GNUC__)


### PR DESCRIPTION
There were two issues:

1. Fix in src/utils/compiler.h

   The build failed when compiling
   src/utils/gmime/gmime-filter-html-bq.c. It complains about a missing
   ')' after 'clang' in line 5 of compiler.h. This is because
   clang::fallthrough is a scoped attribute, but the used macro
   __has_attribute will only accept single identifiers under
   clang. Hence, its sibling __has_cpp_attribute must be used. Then,
   when using the LLVM clang that ships with Xcode, the
   __has_cpp_attribute is not defined at all when compiling
   gmime-filter-html-bq.c. This is because it is a C file, and the LLVM
   clang that ships with Xcode hides the C++ features (including the
   feature checking macros) when operating in C mode. Thus we must
   safeguard against the __has_* macros not being defined. For further
   details, see
   https://isocpp.org/std/standing-documents/sd-6-sg10-feature-test-recommendations
   and
   https://clang.llvm.org/docs/LanguageExtensions.html#feature-checking-macros

2. Fix in SConstruct

   When linking, there were tons of undefined symbol errors against
   stuff from boost log. As pointed out in this stackoverflow answer,
   and as oft:
   https://stackoverflow.com/questions/38121947/boost-log-linking-error-on-osx#answer-38122244
   the order of libs is significant. I think the reordering of the libs
   should be safe for all platforms. Adding the "-mt" suffix was needed
   due to the way Homebrew installs the boost libs (there are no non-mt
   versions). This second one is probably trickier to get right in a
   portable manner, because it seems difficult to make assumptions we
   can hope will generally hold, on how people installed their boost
   libs.