### PR TITLE
markdown: compose messages as markdown and send as multipart/alternative

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,5 +1,6 @@
 ==
 
+* Allow HTML parts to be composed using Markdown.
 * Use color to indicate whether a message is marked in thread-index.
 
 == v0.10.2 / 2017-10-11

--- a/meson.build
+++ b/meson.build
@@ -244,6 +244,7 @@ if not get_option('disable-tests')
 
   tests = [ [ 'generic test',   'test_generic',         [ 'tests/test_generic.cc' ]],
             [ 'compose testing', 'test_composed_message',     [ 'tests/test_composed_message.cc' ]],
+            [ 'markdown',       'test_markdown',        [ 'tests/test_markdown.cc' ]],
             [ 'non existant file', 'test_non_existant_file',  [ 'tests/test_non_existant_file.cc' ]],
             [ 'open db',        'test_open_db',         [ 'tests/test_open_db.cc' ]],
             [ 'convert error',  'test_convert_error',   [ 'tests/test_convert_error.cc' ]],

--- a/src/compose_message.cc
+++ b/src/compose_message.cc
@@ -122,6 +122,9 @@ namespace Astroid {
       body_content += sf.str ();
     }
 
+    markdown_success = false;
+    markdown_error   = "";
+
 
     /* create text part */
     GMimeStream * contentStream = g_mime_stream_mem_new_with_buffer(body_content.c_str(), body_content.size());
@@ -191,8 +194,11 @@ namespace Astroid {
         ch_stderr->read_to_end (_err);
         ch_stderr->close ();
 
-        if (!_err.empty ())
+        if (!_err.empty ()) {
           LOG (error) << "cm: md: " << _err;
+          markdown_error   = _err;
+          markdown_success = false;
+        }
 
         LOG (debug) << "cm: md: got html: " << _html;
 
@@ -201,7 +207,12 @@ namespace Astroid {
       } catch (Glib::SpawnError &ex) {
         LOG (error) << "cm: md: could not convert to markdown!";
         contentStream = g_mime_stream_mem_new_with_buffer("", 0);
+
+        markdown_success = false;
+        markdown_error   = "Failed to spawn markdown processor.";
       }
+
+      markdown_success = true;
 
       /* add output to html part */
       GMimeDataWrapper * contentWrapper = g_mime_data_wrapper_new_with_stream(contentStream, GMIME_CONTENT_ENCODING_DEFAULT);

--- a/src/compose_message.hh
+++ b/src/compose_message.hh
@@ -58,6 +58,9 @@ namespace Astroid {
       bool encrypt = false;
       bool sign    = false;
 
+      bool markdown_success = false;
+      ustring markdown_error = "";
+
       struct Attachment {
         public:
           Attachment ();

--- a/src/compose_message.hh
+++ b/src/compose_message.hh
@@ -54,6 +54,7 @@ namespace Astroid {
       void set_references (ustring);
 
       bool include_signature = false;
+      bool markdown = false;
       bool encrypt = false;
       bool sign    = false;
 

--- a/src/config.cc
+++ b/src/config.cc
@@ -200,6 +200,8 @@ namespace Astroid {
     default_config.put ("editor.attachment_words", "attach");
     default_config.put ("editor.attachment_directory", "~");
 
+    default_config.put ("editor.markdown", "marked");
+
     /* mail composition */
     default_config.put ("mail.reply.quote_line", "Excerpts from %1's message of %2:"); // %1 = author, %2 = pretty_verbose_date
     default_config.put ("mail.reply.mailinglist_reply_to_sender", true);

--- a/src/config.cc
+++ b/src/config.cc
@@ -200,7 +200,7 @@ namespace Astroid {
     default_config.put ("editor.attachment_words", "attach");
     default_config.put ("editor.attachment_directory", "~");
 
-    default_config.put ("editor.markdown", "marked");
+    default_config.put ("editor.markdown_processor", "marked");
 
     /* mail composition */
     default_config.put ("mail.reply.quote_line", "Excerpts from %1's message of %2:"); // %1 = author, %2 = pretty_verbose_date

--- a/src/modes/edit_message.cc
+++ b/src/modes/edit_message.cc
@@ -783,6 +783,10 @@ namespace Astroid {
     /* build message */
     finalize_message (c);
 
+    if (c->markdown && !c->markdown_success) {
+      set_warning ("Failed processing markdown: " + UstringUtils::replace (c->markdown_error, "\n", "<br />"));
+    }
+
     if (c->encrypt || c->sign) {
       if (!c->encryption_success) {
         set_warning ("Failed encrypting: " + UstringUtils::replace (c->encryption_error, "\n", "<br />"));
@@ -1061,6 +1065,12 @@ namespace Astroid {
     ComposeMessage * c = make_message ();
 
     if (c == NULL) return false;
+
+    if (c->markdown && !c->markdown_success) {
+      set_warning ("Cannot send, failed processing markdown: " + UstringUtils::replace (c->markdown_error, "\n", "<br />"));
+      delete c;
+      return false;
+    }
 
     if (c->encrypt || c->sign) {
       if (!c->encryption_success) {

--- a/src/modes/edit_message.cc
+++ b/src/modes/edit_message.cc
@@ -122,6 +122,7 @@ namespace Astroid {
 
     builder->get_widget ("editor_box", editor_box);
     builder->get_widget ("switch_signature", switch_signature);
+    builder->get_widget ("switch_markdown", switch_markdown);
     /*
     builder->get_widget ("editor_rev", editor_rev);
     builder->get_widget ("thread_rev", thread_rev);
@@ -267,6 +268,9 @@ namespace Astroid {
     /* editor->start_editor_when_ready = true; */
 
     switch_signature->property_active().signal_changed ().connect (
+        sigc::mem_fun (*this, &EditMessage::switch_signature_set));
+
+    switch_markdown->property_active().signal_changed ().connect (
         sigc::mem_fun (*this, &EditMessage::switch_signature_set));
 
     switch_encrypt->property_active().signal_changed ().connect (
@@ -465,6 +469,14 @@ namespace Astroid {
             switch_signature->set_active (!switch_signature->get_active ());
           }
           return true;
+        });
+
+    keys.register_key ("M", "edit_message.toggle_markdown",
+        "Toggle markdown",
+        [&] (Key) {
+            switch_markdown->set_active (!switch_markdown->get_active ());
+
+            return true;
         });
 
     keys.register_key ("E", "edit_message.toggle_encrypt",
@@ -1164,6 +1176,7 @@ namespace Astroid {
     } else {
       c->include_signature = false;
     }
+    c->markdown = switch_markdown->get_active ();
 
     if (c->account->has_gpg) {
       c->encrypt = switch_encrypt->get_active ();

--- a/src/modes/edit_message.hh
+++ b/src/modes/edit_message.hh
@@ -43,6 +43,7 @@ namespace Astroid {
 
       Gtk::ComboBox *from_combo, *reply_mode_combo;
       Gtk::Switch   *switch_signature;
+      Gtk::Switch   *switch_markdown;
       Gtk::Switch   *switch_encrypt;
       Gtk::Switch   *switch_sign;
       Gtk::Revealer *fields_revealer;

--- a/tests/test_markdown.cc
+++ b/tests/test_markdown.cc
@@ -1,0 +1,62 @@
+# define BOOST_TEST_DYN_LINK
+# define BOOST_TEST_MODULE TestCompose
+# include <boost/test/unit_test.hpp>
+
+# include "test_common.hh"
+# include "compose_message.hh"
+# include "message_thread.hh"
+# include "chunk.hh"
+# include "account_manager.hh"
+# include "utils/address.hh"
+# include "utils/ustring_utils.hh"
+
+BOOST_AUTO_TEST_SUITE(Markdown)
+
+  BOOST_AUTO_TEST_CASE(compose_read_test)
+  {
+    using Astroid::ComposeMessage;
+    using Astroid::Message;
+    setup ();
+
+    ComposeMessage * c = new ComposeMessage ();
+
+    ustring bdy = "# This is a test";
+
+    c->body << bdy;
+    c->markdown = true;
+
+    c->build ();
+    c->finalize ();
+
+    BOOST_CHECK_MESSAGE (c->markdown_success, c->markdown_error);
+
+    ustring fn = c->write_tmp ();
+
+    Message m (fn);
+
+    /* check plain text part */
+    ustring pbdy = m.viewable_text (false);
+    BOOST_CHECK_MESSAGE (pbdy == bdy, "plain text matches plain text");
+
+    /* check html part */
+    BOOST_CHECK_MESSAGE (g_mime_content_type_is_type (m.root->content_type, "multipart", "alternative"), "main message part is multipart/alternative");
+
+    auto plain = m.root->kids[0];
+    auto html  = m.root->kids[1];
+
+    BOOST_CHECK_MESSAGE (g_mime_content_type_is_type(plain->content_type, "text", "plain"), "first part is text/plain");
+    BOOST_CHECK_MESSAGE (g_mime_content_type_is_type(html->content_type, "text", "html"), "second part is text/html");
+
+    ustring _html = html->viewable_text (false);
+    Astroid::UstringUtils::trim(_html);
+
+    LOG (trace) << "markdown html: '" << _html << "'";
+
+    BOOST_CHECK_MESSAGE ("<h1 id=\"this-is-a-test\">This is a test</h1>" == _html, "html part is correctly constructed html");
+
+    unlink (fn.c_str ());
+    teardown ();
+  }
+
+BOOST_AUTO_TEST_SUITE_END()
+

--- a/ui/edit-message.glade
+++ b/ui/edit-message.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.20.0 -->
+<!-- Generated with glade 3.20.1 -->
 <interface>
   <requires lib="gtk+" version="3.12"/>
   <object class="GtkBox" id="box_message">
@@ -107,6 +107,41 @@
                         <property name="padding">5</property>
                         <property name="pack_type">end</property>
                         <property name="position">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkBox">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="spacing">5</property>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="label" translatable="yes">Markdown:</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkSwitch" id="switch_markdown">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">3</property>
                       </packing>
                     </child>
                   </object>


### PR DESCRIPTION
html and text.

This requires a markdown to html converter like
[marked](https://github.com/chjj/marked). The markdown processor should
read from stdin and output html to stdout.

TODO:
  * Persistent markdown state over drafts (similar to signatures being
      added twic)
  * Always show HTML part when composing (would be great with a better
      UI for showing alternative parts #408)

> Remember that you can toggle the alternative part with Ctrl+Space when in EditMode (usually done with Enter).

__Requires [marked](https://github.com/chjj/marked) to be installed.__

Works as an alternative to: #362.

![2017-11-08-125425_2560x1600_scrot](https://user-images.githubusercontent.com/56827/32547815-081a2658-c484-11e7-9244-702277533ee4.png)
