### PR TITLE
Do not save signature with draft

### DIFF
--- a/src/modes/edit_message.cc
+++ b/src/modes/edit_message.cc
@@ -572,7 +572,7 @@ namespace Astroid {
   bool EditMessage::save_draft () {
     LOG (info) << "em: saving draft..";
     draft_saved = false;
-    ComposeMessage * c = make_message ();
+    ComposeMessage * c = make_draft_message ();
     ustring fname;
 
     bool add_to_notmuch = false;
@@ -1198,8 +1198,23 @@ namespace Astroid {
   }
 
   ComposeMessage * EditMessage::make_message () {
+    return make_message (false);
+  }
+
+  ComposeMessage * EditMessage::make_draft_message () {
+    return make_message (true);
+  }
+
+  ComposeMessage * EditMessage::make_message (bool draft = false) {
     ComposeMessage * c = setup_message ();
+    bool sigstate = c->account->has_signature;
+
+    if (draft) {
+      /* Do not save signature in a draft */
+      c->account->has_signature = false;
+    }
     finalize_message (c);
+    c->account->has_signature = sigstate;
 
     return c;
   }
@@ -1320,4 +1335,3 @@ namespace Astroid {
   // }}}
 
 }
-

--- a/src/modes/edit_message.hh
+++ b/src/modes/edit_message.hh
@@ -100,6 +100,7 @@ namespace Astroid {
       ComposeMessage * setup_message ();
       void             finalize_message (ComposeMessage *);
       ComposeMessage * make_message ();
+      ComposeMessage * make_draft_message ();
 
       ComposeMessage * sending_message;
       std::atomic<bool> sending_in_progress;
@@ -155,6 +156,8 @@ namespace Astroid {
 
       bool message_sent = false;
       void lock_message_after_send ();
+
+      ComposeMessage * make_message (bool draft);
 
     private:
       void on_from_combo_changed ();


### PR DESCRIPTION
Don't save the signature with the draft. 
(Temporary) solution for issue #234 