### PR TITLE
poll: optionally do full refresh; also triggerbale by --refresh 0

### DIFF
--- a/src/config.cc
+++ b/src/config.cc
@@ -217,6 +217,7 @@ namespace Astroid {
 
     /* polling */
     default_config.put ("poll.interval", Poll::DEFAULT_POLL_INTERVAL); // seconds
+    default_config.put ("poll.always_full_refresh", false); // always do full refresh after poll, slow.
 
     /* attachments
      *

--- a/src/poll.hh
+++ b/src/poll.hh
@@ -32,6 +32,7 @@ namespace Astroid {
       int poll_interval = 0;
       bool auto_polling_enabled = true;
       bool external_polling = false;
+      bool full_refresh = false;
 
       bool periodic_polling ();
 
@@ -40,6 +41,7 @@ namespace Astroid {
 
       unsigned long before_poll_revision = 0;
       void refresh_threads ();
+      void refresh_full ();
 
       std::mutex  poll_cancel_m;
       std::condition_variable poll_cancel_cv;


### PR DESCRIPTION
#452 

Either set new configuration option: poll.always_full_refresh = true or do `astroid --refresh 0`. Not really tested.