### PR TITLE
Fix passing flags to compile tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,7 +210,9 @@ include(CheckCXXSourceRuns)
 unset ( CMAKE_REQUIRED_FLAGS )
 unset ( CMAKE_REQUIRED_INCLUDES )
 unset ( CMAKE_REQUIRED_LIBRARIES )
-list ( APPEND CMAKE_REQUIRED_FLAGS     ${GMIME_CFLAGS} )
+# try_run will get confused and pass flags to cmake instead if they are connected with ";"
+string ( REPLACE ";" "," NEW_CFLAGS "${GMIME_CFLAGS}" )
+list ( APPEND CMAKE_REQUIRED_FLAGS "${NEW_CFLAGS}" )
 list ( APPEND CMAKE_REQUIRED_INCLUDES  ${GMIME_INCLUDE_DIRS} ${NOTMUCH_INCLUDE_DIRS} )
 list ( APPEND CMAKE_REQUIRED_LIBRARIES ${NOTMUCH_LIBRARIES} ${GMIME_LDFLAGS} )
 


### PR DESCRIPTION
`try_run`, used by `CheckCXXSourceRuns`, will get confused and pass flags to cmake instead if they are connected with ";", resulting in the error:

```
-- Performing Test GMIME_MATCHES
Parse error in command line argument: -D_LARGEFILE64_SOURCE
Should be: VAR:type=value
CMake Error: No cmake script provided.
CMake Error at /usr/share/cmake/Modules/CheckCXXSourceRuns.cmake:85 (try_run):
  Failed to configure test project build system.
Call Stack (most recent call first):
  CMakeLists.txt:217 (CHECK_CXX_SOURCE_RUNS)
```

This patch solves it by using the safer "," separator for flags.