### PR TITLE
Disable format=flowed as Content-Type for new mails

### DIFF
--- a/src/compose_message.cc
+++ b/src/compose_message.cc
@@ -131,7 +131,6 @@ namespace Astroid {
     GMimePart * messagePart = g_mime_part_new_with_type ("text", "plain");
 
     g_mime_object_set_content_type_parameter ((GMimeObject *) messagePart, "charset", astroid->config().get<string>("editor.charset").c_str());
-    g_mime_object_set_content_type_parameter ((GMimeObject *) messagePart, "format", "flowed");
 
     GMimeDataWrapper * contentWrapper = g_mime_data_wrapper_new_with_stream(contentStream, GMIME_CONTENT_ENCODING_DEFAULT);
 
@@ -168,7 +167,6 @@ namespace Astroid {
       /* construct HTML part */
       GMimePart * html = g_mime_part_new_with_type ("text", "html");
       g_mime_object_set_content_type_parameter ((GMimeObject *) html, "charset", astroid->config().get<string>("editor.charset").c_str());
-      g_mime_object_set_content_type_parameter ((GMimeObject *) html, "format", "flowed");
 
       GMimeStream * contentStream;
 


### PR DESCRIPTION
This is a very simplistic approach to solve #446. It just does not add `format=flowed` in the Content-Type header.

format=flowed causes some sick issues in combination with quoted-printable and special characters because astroid (or gmime) does no proper space stuffing to mitigate the automatic line breaks caused by quoted-printable. This can not be resolved by changes in the editor AFAIU. More about the problem in the issue.

Some people have raised that they would like to keep format=flowed as an option which isn't covered in this PR because I lack the skills to realise it. Nevertheless this PR solves an existing bug and doesn't really make new mails extremely ugly or something, so we could still work on adding an improved implementation of format=flowed later IMHO (except someone comes up with a solution quite soon).

cc @kirschner