### PR TITLE
Add Header Files to Xcode Projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -387,6 +387,15 @@ target_link_libraries (
   ${Gettext_LDFLAGS}
   )
 
+# Xcode needs to be explicitly told about the header files in order to
+# show them in the project and automatically display them in the
+# assitant editor
+if(CMAKE_GENERATOR STREQUAL "Xcode")
+  message(STATUS "Xcode build: adding headers to project")
+  file(GLOB_RECURSE my_header_files src/ "*.h" "*.hh")
+  target_sources(hypocycloid PRIVATE ${my_header_files})
+endif()
+
 ##
 # conditional compilation based on feature switches
 #


### PR DESCRIPTION
Xcode needs to be told explicitly about the header files to show them in
the project, and to be able to automatically select them in the\
assistant editors.