### PR TITLE
hooks: undo hooks

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,8 +1,9 @@
 == **
 * `mail.close_on_success` configures if page closes on successful send.
 * `terminal.font_description` configures font of embedded terminal.
-* `termina.height` configures height of embedded terminal.
+* `terminal.height` configures height of embedded terminal.
 * `mail.format_flowed` is off by default.
+* Make hooks undoable by providing a field for the inverse command.
 
 == v0.11.1 / 2018-02-20
 

--- a/src/actions/cmdaction.cc
+++ b/src/actions/cmdaction.cc
@@ -18,11 +18,11 @@ namespace Astroid {
   }
 
   bool CmdAction::undo (Db *) {
-    return false;
+    return cmd.undo ();
   }
 
   bool CmdAction::undoable () {
-    return false;
+    return cmd.undoable ();
   }
 
   void CmdAction::emit (Db * db) {

--- a/src/modes/keybindings.hh
+++ b/src/modes/keybindings.hh
@@ -101,7 +101,7 @@ namespace Astroid {
                          std::function<bool (Key)>);
 
       void register_run (ustring name,
-                         std::function<bool (Key, ustring)>);
+                         std::function<bool (Key, ustring, ustring)>);
 
       bool handle (GdkEventKey *);
       bool handle (ustring name);
@@ -116,7 +116,7 @@ namespace Astroid {
       ustring prefix = "";
 
       static std::vector<Key>  user_bindings;
-      static std::vector<std::pair<Key, ustring>> user_run_bindings;
+      static std::vector<std::pair<Key, std::pair<ustring, ustring>>> user_run_bindings;
 
       static std::atomic<bool> user_bindings_loaded;
       static const char * user_bindings_file;

--- a/src/modes/thread_index/thread_index_list_view.cc
+++ b/src/modes/thread_index/thread_index_list_view.cc
@@ -1009,14 +1009,15 @@ namespace Astroid {
         });
 
     keys->register_run ("thread_index.run",
-        [&] (Key, ustring cmd) {
+        [&] (Key, ustring cmd, ustring undo_cmd) {
           auto t = get_current_thread ();
 
           if (t) {
             cmd = ustring::compose (cmd, t->thread_id);
+            undo_cmd = ustring::compose (undo_cmd, t->thread_id);
 
             astroid->actions->doit (refptr<Action> (new CmdAction (
-                    Cmd ("thread_index.run", cmd), t->thread_id, "")));
+                    Cmd ("thread_index.run", cmd, undo_cmd), t->thread_id, "")));
 
           }
 

--- a/src/modes/thread_view/thread_view.cc
+++ b/src/modes/thread_view/thread_view.cc
@@ -2660,13 +2660,13 @@ namespace Astroid {
         });
 
     keys.register_run ("thread_view.run",
-	[&] (Key, ustring cmd) {
+	[&] (Key, ustring cmd, ustring undo_cmd) {
           if (!edit_mode && focused_message) {
-
             cmd = ustring::compose (cmd, focused_message->tid, focused_message->mid);
+            undo_cmd = ustring::compose (undo_cmd, focused_message->tid, focused_message->mid);
 
             astroid->actions->doit (refptr<Action> (new CmdAction (
-              Cmd ("thread_view.run", cmd), focused_message->tid, focused_message->mid)));
+              Cmd ("thread_view.run", cmd, undo_cmd), focused_message->tid, focused_message->mid)));
 
             }
           return true;

--- a/src/utils/cmd.hh
+++ b/src/utils/cmd.hh
@@ -11,14 +11,20 @@ namespace Astroid {
   class Cmd {
     public:
       Cmd ();
-      Cmd (ustring prefix, ustring cmd);
-      Cmd (ustring cmd);
+      Cmd (ustring prefix, ustring cmd, ustring undo_cmd);
+      Cmd (ustring cmd, ustring undo_cmd);
 
-      int run (); /* currently only in sync */
+      int run ();
+      int undo ();
+
+      bool undoable ();
 
     private:
       ustring prefix;
       ustring cmd;
+      ustring undo_cmd;
+
+      int execute (bool undo); /* currently only in sync */
 
       ustring substitute (ustring);
   };

--- a/tests/test_home/keybindings
+++ b/tests/test_home/keybindings
@@ -22,8 +22,14 @@ test.run(echo %1)=n
 test.run(echo %1)=y
 
 # reasign a key to a hook
-test.run(echo %1)=4
-test.run(echo %1)=5
+test.run(echo %1, echo undo %1)=4
+test.run(echo %1, echo undo %1)=5
+test.run(echo %1\, no undo)=6
+test.run(echo %1\, no undo, echo real undo %1)=7
+
+# these fail
+test.run(echo %1, echo undo, %1)=5
+test.run(,echo %1\, echo undo %1)=5
 
 
 # replacing an existing non-userdefined binding

--- a/tests/test_keybindings.cc
+++ b/tests/test_keybindings.cc
@@ -76,13 +76,17 @@ BOOST_AUTO_TEST_SUITE(TestTestKeybindings)
     /* test run hook */
     ustring test_thread = "001";
 
-    auto f = [&] (Key, ustring cmd) {
-      LOG (test) << "key: run-hook got back: " << cmd;
+    auto f = [&] (Key, ustring cmd, ustring undo) {
+      LOG (test) << "key: run-hook got back: " << cmd << ", undo: " << undo;
 
       ustring final_cmd = ustring::compose (cmd, test_thread);
+      ustring final_undo_cmd = ustring::compose (undo, test_thread);
       LOG (test) << "key: would run: " << final_cmd;
+      LOG (test) << "key: would undo: " << final_undo_cmd;
 
-      Cmd("test", final_cmd).run ();
+      auto c = Cmd("test", final_cmd, final_undo_cmd);
+      c.run ();
+      c.undo ();
 
       return true;
     };


### PR DESCRIPTION
Use thread_view.run(cmd, undo_cmd)=w to specify a undo command for
hooks. undo_cmd takes the same arguments as cmd. Specifying no undo_cmd
is allowed and is equivalent to having and empty field in undo_cmd.
Escape ',' in your cmds with '\,'.

Need to be updated: https://github.com/astroidmail/astroid/wiki/User-defined-keyboard-hooks