### PR TITLE
fix #491: opening next unread from thread-view causes crash when quer…

### DIFF
--- a/src/modes/thread_index/thread_index.cc
+++ b/src/modes/thread_index/thread_index.cc
@@ -257,6 +257,11 @@ namespace Astroid {
   }
 
   bool ThreadIndex::on_index_action (ThreadView * tv, ThreadView::IndexAction action) {
+
+    if (list_view->filtered_store->children().size() < 2) {
+      return true;
+    }
+
     switch (action) {
       case ThreadView::IndexAction::IA_Next:
         {


### PR DESCRIPTION
…y is empty.