### PR TITLE
Fix tests

### DIFF
--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -49,7 +49,7 @@ if [ ! -e ${NOTMUCH_CONFIG} ]; then
 
   # set up theme
   mkdir -p ${BINDIR}/ui
-  cp ${SRCDIR}/ui/*.{scss,css,html} ${BINDIR}/ui/
+  find "${SRCDIR}/ui/" \( -name "*.scss" -o -name "*.html" -o -name "*.css" \) -exec cp -v {} "${BINDIR}/ui/" \;
 fi
 
 echo "Running: ${TEST}.."

--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -4,8 +4,8 @@
 
 set -ep
 
-SRCDIR=${1}
-BINDIR=${2}
+SRCDIR="${1}"
+BINDIR="${2}"
 TEST=${3}
 
 echo "Source dir: ${SRCDIR}"
@@ -17,7 +17,7 @@ export ASTROID_BUILD_DIR="${BINDIR}"
 
 gpgconf --kill all # stop all components
 
-if [ ! -e ${NOTMUCH_CONFIG} ]; then
+if [ ! -e "${NOTMUCH_CONFIG}" ]; then
   echo "Setting up test suite.."
 
   notmuch_db="${BINDIR}/tests/mail/test_mail"
@@ -27,34 +27,33 @@ if [ ! -e ${NOTMUCH_CONFIG} ]; then
   cp "${SRCDIR}/tests/mail/test_config.template" "${NOTMUCH_CONFIG}"
   notmuch config set database.path "${notmuch_db}"
 
-  cp    ${SRCDIR}/tests/mail/*.eml ${notmuch_db}/..
-  cp -r ${SRCDIR}/tests/mail/test_mail/* ${notmuch_db}/
+  cp    "${SRCDIR}/tests/mail/"*.eml "${notmuch_db}/.."
+  cp -r "${SRCDIR}/tests/mail/test_mail/"* "${notmuch_db}/"
   notmuch new
 
-  cp "${SRCDIR}/tests/forktee"* "${BINDIR}/tests/"
-
+  cp    "${SRCDIR}/tests/forktee"* "${BINDIR}/tests/"
   cp -r "${SRCDIR}/tests/test_home" "${BINDIR}/tests/"
 
   # setup GPG
-  mkdir -p ${GNUPGHOME}
-  chmod og-rwx ${GNUPGHOME}
+  mkdir -p "${GNUPGHOME}"
+  chmod og-rwx "${GNUPGHOME}"
 
-  pushd ${GNUPGHOME}
-  gpg --batch --gen-key ${SRCDIR}/tests/foo1.key
-  gpg --batch --gen-key ${SRCDIR}/tests/foo2.key
+  pushd "${GNUPGHOME}"
+  gpg --batch --gen-key "${SRCDIR}/tests/foo1.key"
+  gpg --batch --gen-key "${SRCDIR}/tests/foo2.key"
   gpg --batch --always-trust --import one.pub
   gpg --batch --always-trust --import two.pub
   echo "always-trust" > gpg.conf
   popd
 
   # set up theme
-  mkdir -p ${BINDIR}/ui
+  mkdir -p "${BINDIR}/ui"
   find "${SRCDIR}/ui/" \( -name "*.scss" -o -name "*.html" -o -name "*.css" \) -exec cp -v {} "${BINDIR}/ui/" \;
 fi
 
 echo "Running: ${TEST}.."
 
-pushd ${BINDIR}
+pushd "${BINDIR}"
 ./tests/${TEST}
 popd
 


### PR DESCRIPTION
Using a wildcard for specifying files would fail when there are no *.css files. I replaced it with find so it's foolproof.

Also, if someone had spaces in the path they test astroid in the whole thing would explode, so please quote all of them.