### PR TITLE
add syslog backend and make logging sinks and level configurable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,6 +168,7 @@ add_compile_options (
   )
 add_definitions (
   -DBOOST_LOG_DYN_LINK
+  -DBOOST_LOG_USE_NATIVE_SYSLOG
   )
 #
 # debug builds

--- a/History.txt
+++ b/History.txt
@@ -26,6 +26,9 @@
 * Do not allow images in encrypted messages (#499)
 * Show CID (attached) images in HTML parts (on C-i)
 * Zoom messages with C-+ and C--
+* Logging can be configured to go to syslog (or stdout, default). File logging
+  is removed since we now have multiple processes and this would complicate
+  writing to one file.
 
 == v0.12
 * `mail.close_on_success` configures if page closes on successful send.

--- a/examples/astroid
+++ b/examples/astroid
@@ -15,5 +15,5 @@ export ASTROID_DIR=$(dirname $ASTROID_DIR)/..
 # GIR
 export GI_TYPELIB_PATH=$ASTROID_DIR/build
 
-unbuffer $ASTROID_DIR/build/astroid -l ~/.config/astroid/log $*
+$ASTROID_DIR/build/astroid $*
 

--- a/src/astroid.hh
+++ b/src/astroid.hh
@@ -19,7 +19,8 @@
 
 # include "proto.hh"
 
-namespace po = boost::program_options;
+namespace po      = boost::program_options;
+namespace logging = boost::log;
 
 namespace Astroid {
   class Astroid : public Gtk::Application {
@@ -31,7 +32,25 @@ namespace Astroid {
 
       int run (int, char**);
       void main_test ();
-      void init_log ();
+
+      void init_console_log ();
+      void init_sys_log ();
+      bool log_stdout   = true;
+      bool log_syslog   = false;
+      bool disable_log  = false;
+
+      ustring log_level = "debug";
+      std::map<std::string, logging::trivial::severity_level> sevmap = {
+        std::pair<std::string,logging::trivial::severity_level>("trace"  , logging::trivial::trace),
+        std::pair<std::string,logging::trivial::severity_level>("debug"  , logging::trivial::debug),
+        std::pair<std::string,logging::trivial::severity_level>("info"   , logging::trivial::info),
+        std::pair<std::string,logging::trivial::severity_level>("warning", logging::trivial::warning),
+        std::pair<std::string,logging::trivial::severity_level>("error"  , logging::trivial::error),
+        std::pair<std::string,logging::trivial::severity_level>("fatal"  , logging::trivial::fatal),
+      };
+
+      const std::string log_ident = "astroid.main";
+
 
       const boost::property_tree::ptree& config (const std::string& path=std::string()) const;
       const boost::property_tree::ptree& notmuch_config () const;
@@ -73,7 +92,6 @@ namespace Astroid {
       void send_mailto (ustring);
 
 
-      static std::atomic<bool> log_initialized;
       int _hint_level = 0;
       po::options_description desc;
   };

--- a/src/config.cc
+++ b/src/config.cc
@@ -124,6 +124,15 @@ namespace Astroid {
     /* only show hints with a level higher than this */
     default_config.put ("astroid.hints.level", 0);
 
+    default_config.put ("astroid.log.syslog", false);
+    default_config.put ("astroid.log.stdout", true);
+
+# if DEBUG
+    default_config.put ("astroid.log.level", "debug"); // (trace, debug, info, warning, error, fatal)
+# else
+    default_config.put ("astroid.log.level", "info"); // (trace, debug, info, warning, error, fatal)
+# endif
+
     if (initial) {
       /* initial default options - these are only set when a new
        * configuration file is created. */

--- a/src/modes/thread_view/page_client.cc
+++ b/src/modes/thread_view/page_client.cc
@@ -197,6 +197,11 @@ namespace Astroid {
     s.set_part_css (thread_view->theme.part_css.c_str ());
     s.set_html (thread_view->theme.thread_view_html.c_str ());
 
+    s.set_use_stdout (astroid->log_stdout);
+    s.set_use_syslog (astroid->log_syslog);
+    s.set_disable_log (astroid->disable_log);
+    s.set_log_level (astroid->log_level);
+
     /* send allowed URIs */
     if (enable_gravatar) {
       s.add_allowed_uris ("https://www.gravatar.com/avatar/");

--- a/src/modes/thread_view/webextension/messages.proto
+++ b/src/modes/thread_view/webextension/messages.proto
@@ -80,7 +80,13 @@ message Page {
   string html = 1;
   string css = 2;
   string part_css = 3;
+
   repeated string allowed_uris = 4;
+
+  bool   use_stdout = 5;
+  bool   use_syslog = 6;
+  bool   disable_log = 7;
+  string log_level = 8;
 }
 
 message Info {

--- a/src/modes/thread_view/webextension/tvextension.hh
+++ b/src/modes/thread_view/webextension/tvextension.hh
@@ -8,11 +8,14 @@
 # include <giomm/socket.h>
 # include <thread>
 # include <mutex>
+# include <boost/log/trivial.hpp>
 
 # include "messages.pb.h"
 
 # define refptr Glib::RefPtr
 typedef Glib::ustring ustring;
+
+namespace logging = boost::log;
 
 extern "C" {
 
@@ -61,6 +64,20 @@ class AstroidExtension {
     bool        run = true;
     refptr<Gio::Cancellable> reader_cancel;
     void        ack (bool success);
+
+    void init_console_log ();
+    void init_sys_log ();
+    const std::string log_ident = "astroid.wext";
+
+    std::map<std::string, logging::trivial::severity_level> sevmap = {
+      std::pair<std::string,logging::trivial::severity_level>("trace"  , logging::trivial::trace),
+      std::pair<std::string,logging::trivial::severity_level>("debug"  , logging::trivial::debug),
+      std::pair<std::string,logging::trivial::severity_level>("info"   , logging::trivial::info),
+      std::pair<std::string,logging::trivial::severity_level>("warning", logging::trivial::warning),
+      std::pair<std::string,logging::trivial::severity_level>("error"  , logging::trivial::error),
+      std::pair<std::string,logging::trivial::severity_level>("fatal"  , logging::trivial::fatal),
+    };
+
 
     WebKitDOMNode * container;
 


### PR DESCRIPTION
remove file log and add syslog. the multi-process design we have now
would require careful handling when output to one file.

syslog and stdout config options for the log are created. as well as one
config option for setting the log-level (fixes #419). the corresponding
log-level option is removed as executable argument. a --log-stdout
argument is added. and --disable-log still overrides.

> LogView does not work with only syslog backend.