### PR TITLE
Problem: tests/run-test.sh might fail

### DIFF
--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 #
 # Set up environment and run test specified on command line
 


### PR DESCRIPTION
This is because on some systems, bash is not in
/bin/bash

Solution: use /usr/bin/env bash in the shebang