### PR TITLE
cmake: fix scalable icon install path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -513,7 +513,7 @@ install_symlink (../../../../astroid/ui/icons/icon_color.png
   ${CMAKE_INSTALL_PREFIX}/share/icons/hicolor/512x512/apps/astroid.png
   )
 install_symlink (../../../../astroid/ui/icons/icon_color.svg
-  ${CMAKE_INSTALL_PREFIX}/share/icons/hicolor/scalable/app/astroid.svg
+  ${CMAKE_INSTALL_PREFIX}/share/icons/hicolor/scalable/apps/astroid.svg
   )
 
 install (FILES ui/astroid.desktop


### PR DESCRIPTION
The correct path is apps, not app*.