### PR TITLE
fix #501: Add hook to signal_delete_event, ensure proper destruction of window

### DIFF
--- a/src/main_window.cc
+++ b/src/main_window.cc
@@ -203,6 +203,10 @@ namespace Astroid {
     update_title_dispatcher.connect (
         sigc::mem_fun (this, &MainWindow::on_update_title));
 
+    /* catch window close events */
+    signal_delete_event ().connect (
+        sigc::mem_fun (this, &MainWindow::on_delete_event));
+
     /* register keys {{{ */
     keys.title = "MainWindow";
 
@@ -635,6 +639,12 @@ namespace Astroid {
     }
 
     close (); // Gtk::Window::close ()
+  }
+
+  bool MainWindow::on_delete_event (GdkEventAny *) {
+    if (!in_quit)
+      quit ();
+    return false;
   }
 
   void MainWindow::on_yes () {

--- a/src/main_window.hh
+++ b/src/main_window.hh
@@ -117,6 +117,7 @@ namespace Astroid {
       void set_title (ustring);
 
       void quit ();
+      bool on_delete_event (GdkEventAny *);
 
       Glib::Dispatcher update_title_dispatcher;
 


### PR DESCRIPTION
Signal documented here: https://developer.gnome.org/gtkmm/stable/classGtk_1_1Widget.html#a3986616c9bc5ed3bb3bcc450ec80d54c