### PR TITLE
cm: use GMimeStreamMem to avoid writing tmp file

### DIFF
--- a/src/chunk.cc
+++ b/src/chunk.cc
@@ -238,6 +238,10 @@ namespace Astroid {
 
   }
 
+  bool Chunk::is_content_type (const char * major, const char * minor) {
+    return (mime_object != NULL) && g_mime_content_type_is_type (content_type, major, minor);
+  }
+
   ustring Chunk::viewable_text (bool html = true, bool verbose) {
     if (isencrypted && !crypt->decrypted) {
       if (verbose) {
@@ -258,7 +262,7 @@ namespace Astroid {
       LOG (debug) << "chunk: body: part";
 
 
-      if (g_mime_content_type_is_type (content_type, "text", "plain")) {
+      if (is_content_type ("text", "plain")) {
         LOG (debug) << "chunk: plain text (out html: " << html << ")";
 
         GMimeDataWrapper * content = g_mime_part_get_content (
@@ -328,7 +332,7 @@ namespace Astroid {
 
         content_stream = filter_stream;
 
-      } else if (g_mime_content_type_is_type (content_type, "text", "html")) {
+      } else if (is_content_type ("text", "html")) {
         LOG (debug) << "chunk: html text";
 
         GMimeDataWrapper * content = g_mime_part_get_content (

--- a/src/chunk.hh
+++ b/src/chunk.hh
@@ -30,6 +30,7 @@ namespace Astroid {
       ustring content_id;
 
       ustring get_content_type ();
+      bool    is_content_type (const char* major, const char* minor);
 
       ustring viewable_text (bool, bool verbose = false);
 

--- a/src/compose_message.cc
+++ b/src/compose_message.cc
@@ -283,8 +283,7 @@ namespace Astroid {
 
     set_subject (msg.subject);
 
-    body << msg.viewable_text (false);
-
+    body << msg.plain_text (false);
   }
 
   void ComposeMessage::finalize () {

--- a/src/compose_message.cc
+++ b/src/compose_message.cc
@@ -731,6 +731,18 @@ namespace Astroid {
     LOG (debug) << "cm: wrote file: " << fname;
   }
 
+  void ComposeMessage::write (GMimeStream * stream) {
+    g_object_ref (stream);
+
+    g_mime_object_write_to_stream (GMIME_OBJECT(message), g_mime_format_options_get_default (), stream);
+    g_mime_stream_flush (stream);
+    g_mime_stream_seek (stream, 0, GMIME_STREAM_SEEK_SET);
+
+    g_object_unref(stream);
+
+    LOG (debug) << "cm: wrote to stream.";
+  }
+
   ComposeMessage::Attachment::Attachment () {
   }
 

--- a/src/compose_message.hh
+++ b/src/compose_message.hh
@@ -93,6 +93,7 @@ namespace Astroid {
       bool cancel_sending ();
       ustring write_tmp (); // write message to tmpfile
       void write (ustring); // write message to some file
+      void write (GMimeStream *); // write to stream
 
       /* encryption */
       bool encryption_success = false;

--- a/src/message_thread.cc
+++ b/src/message_thread.cc
@@ -324,13 +324,13 @@ namespace Astroid {
       bool use = false;
 
       if (c->siblings.size() >= 1) {
-        if (c->preferred) {
+        if (c->is_content_type ("text", html ? "html" : "plain")) {
           use = true;
         } else {
           /* check if there are any other preferred */
           if (all_of (c->siblings.begin (),
                       c->siblings.end (),
-                      [](refptr<Chunk> c) { return (!c->preferred); })) {
+                      [html](refptr<Chunk> c) { return !c->is_content_type ("text", html ? "html" : "plain"); })) {
             use = true;
           } else {
             use = false;
@@ -341,7 +341,7 @@ namespace Astroid {
       }
 
       if (use) {
-        if (c->viewable && (c->preferred || html || fallback_html)) {
+        if (c->viewable && (c->is_content_type ("text", html ? "html" : "plain") ||  fallback_html)) {
           body += c->viewable_text (html);
         }
 

--- a/src/message_thread.hh
+++ b/src/message_thread.hh
@@ -17,6 +17,7 @@ namespace Astroid {
       Message (ustring _mid, ustring _fname);
       Message (notmuch_message_t *, int _level);
       Message (GMimeMessage *);
+      Message (GMimeStream *);
       Message (refptr<NotmuchMessage>, int _level = 0);
       ~Message ();
 
@@ -145,6 +146,7 @@ namespace Astroid {
       void load_messages (Db *);
       void add_message (ustring);
       void add_message (refptr<Chunk>);
+      void add_message (refptr<Message>);
   };
 }
 

--- a/src/message_thread.hh
+++ b/src/message_thread.hh
@@ -63,10 +63,10 @@ namespace Astroid {
       ustring date ();
       ustring date_asctime ();
       ustring pretty_date ();
-      ustring pretty_verbose_date (bool = false);
+      ustring pretty_verbose_date (bool include_short = false);
       std::vector<ustring> tags;
 
-      ustring viewable_text (bool, bool fallback_html = false);
+      ustring plain_text (bool fallback_html = false);
       std::vector<refptr<Chunk>> attachments ();
       refptr<Chunk> get_chunk_by_id (int id);
 

--- a/src/modes/edit_message.cc
+++ b/src/modes/edit_message.cc
@@ -337,10 +337,14 @@ namespace Astroid {
         [&] (Key) {
           /* view raw source of to be sent message */
           ComposeMessage * c = make_message ();
-          ustring tmpf = c->write_tmp ();
 
-          main_window->add_mode (new RawMessage (main_window, tmpf.c_str(), true));
-          /* tmp file deleted by RawMessage */
+          GMimeStream * m = g_mime_stream_mem_new ();
+          assert (g_mime_stream_mem_get_owner (GMIME_STREAM_MEM(m)) == true);
+          c->write (m);
+
+          main_window->add_mode (new RawMessage (main_window, refptr<Message>(new Message(m))));
+
+          g_object_unref (m);
 
           delete c;
 
@@ -806,15 +810,16 @@ namespace Astroid {
     subject = c->subject;
     body = ustring(c->body.str());
 
-    ustring tmpf = c->write_tmp ();
+    GMimeStream * m = g_mime_stream_mem_new ();
+    assert (g_mime_stream_mem_get_owner (GMIME_STREAM_MEM(m)) == true);
+    c->write (m);
 
     auto msgt = refptr<MessageThread>(new MessageThread());
-    msgt->add_message (tmpf);
+    msgt->add_message (refptr<Message>(new Message(m)));
     thread_view->load_message_thread (msgt);
 
+    g_object_unref (m);
     delete c;
-
-    unlink (tmpf.c_str());
 
     in_read = false;
   }

--- a/src/modes/forward_message.cc
+++ b/src/modes/forward_message.cc
@@ -67,7 +67,7 @@ namespace Astroid {
         quoted << "Cc: " << AddressList(msg->cc()).str () << endl;
       quoted << endl;
 
-      string vt = msg->viewable_text(false);
+      string vt = msg->plain_text (false);
       quoted << vt;
 
       body = ustring(quoted.str());

--- a/src/modes/raw_message.cc
+++ b/src/modes/raw_message.cc
@@ -132,7 +132,11 @@ namespace Astroid {
     stringstream s;
 
     /* add filenames */
-    s << "Filename: " << msg->fname << endl << endl;
+    if (msg->has_file) {
+      s << "Filename: " << msg->fname << endl << endl;
+    } else {
+      s << "Filename: (none, memory)"<< endl << endl;
+    }
 
     auto c = msg->raw_contents ();
     auto cnv = UstringUtils::bytearray_to_ustring (c);

--- a/src/modes/reply_message.cc
+++ b/src/modes/reply_message.cc
@@ -56,7 +56,7 @@ namespace Astroid {
     quoted  << quoting_a.raw ()
             << endl;
 
-    string vt = msg->viewable_text(false);
+    string vt = msg->plain_text (false);
     stringstream sstr (vt);
     while (sstr.good()) {
       string line;

--- a/src/modes/thread_view/page_client.cc
+++ b/src/modes/thread_view/page_client.cc
@@ -455,7 +455,7 @@ namespace Astroid {
 
     /* set preview */
     {
-      ustring bp = m->viewable_text (false, false);
+      ustring bp = m->plain_text (false);
       if (static_cast<int>(bp.size()) > MAX_PREVIEW_LEN)
         bp = bp.substr(0, MAX_PREVIEW_LEN - 3) + "...";
 

--- a/src/modes/thread_view/thread_view.cc
+++ b/src/modes/thread_view/thread_view.cc
@@ -1153,7 +1153,7 @@ namespace Astroid {
           for (auto &m : mthread->messages) {
             MessageState s = state[m];
             if (s.marked) {
-              y += m->viewable_text (false, true);
+              y += m->plain_text (true);
               y += "\n";
             }
           }
@@ -1709,7 +1709,7 @@ namespace Astroid {
         auto cp = Gtk::Clipboard::get (astroid->clipboard_target);
         ustring t;
 
-        t = focused_message->viewable_text (false, true);
+        t = focused_message->plain_text (true);
 
         cp->set_text (t);
       }
@@ -1739,7 +1739,7 @@ namespace Astroid {
           auto cp = Gtk::Clipboard::get (astroid->clipboard_target);
           ustring t;
 
-          t = focused_message->viewable_text (false, true);
+          t = focused_message->plain_text (true);
 
           cp->set_text (t);
         }

--- a/tests/test_bad_content_id.cc
+++ b/tests/test_bad_content_id.cc
@@ -30,7 +30,7 @@ BOOST_AUTO_TEST_SUITE(Reading)
 
     Message m (fname);
 
-    BOOST_CHECK_NO_THROW (m.viewable_text (true));
+    BOOST_CHECK_NO_THROW (m.plain_text (true));
 
     /* the first part is probablematic */
     /* refptr<Chunk> c = m.root->kids[0]; */
@@ -60,7 +60,7 @@ BOOST_AUTO_TEST_SUITE(Reading)
 
     Message m (fname);
 
-    BOOST_CHECK_NO_THROW (m.viewable_text (true));
+    BOOST_CHECK_NO_THROW (m.plain_text (true));
 
     /* the first part is probablematic */
     /* refptr<Chunk> c = m.root->kids[0]; */

--- a/tests/test_composed_message.cc
+++ b/tests/test_composed_message.cc
@@ -45,7 +45,7 @@ BOOST_AUTO_TEST_SUITE(Composing)
 
     Message m (fn);
 
-    ustring rbdy = m.viewable_text (false);
+    ustring rbdy = m.plain_text (false);
 
     BOOST_CHECK_MESSAGE (bdy == rbdy, "message reading produces the same output as compose message input");
 
@@ -143,7 +143,7 @@ BOOST_AUTO_TEST_SUITE(Composing)
       BOOST_CHECK (m.subject == subject);
       BOOST_CHECK (AddressList(m.to()).str () == to);
       BOOST_CHECK (m.mid == id);
-      BOOST_CHECK (m.viewable_text (false) == (body + signature));
+      BOOST_CHECK (m.plain_text (false) == (body + signature));
 
       unlink (fname.c_str ());
     }
@@ -175,7 +175,7 @@ BOOST_AUTO_TEST_SUITE(Composing)
 
     Message m (fn);
 
-    ustring rbdy = m.viewable_text (false);
+    ustring rbdy = m.plain_text (false);
 
     BOOST_CHECK_MESSAGE (bdy == rbdy, "message reading produces the same output as compose message input");
 

--- a/tests/test_composed_message.cc
+++ b/tests/test_composed_message.cc
@@ -8,6 +8,7 @@
 # include "account_manager.hh"
 # include "utils/address.hh"
 # include "utils/ustring_utils.hh"
+# include <boost/property_tree/ptree.hpp>
 
 BOOST_AUTO_TEST_SUITE(Composing)
 
@@ -147,6 +148,38 @@ BOOST_AUTO_TEST_SUITE(Composing)
       unlink (fname.c_str ());
     }
 
+    teardown ();
+  }
+
+  BOOST_AUTO_TEST_CASE (compose_test_body_preferred_html)
+  {
+    using Astroid::ComposeMessage;
+    using Astroid::Message;
+    using boost::property_tree::ptree;
+
+    setup ();
+    const_cast<ptree&>(astroid->config()).put ("thread_view.preferred_type", "html");
+
+    ComposeMessage * c = new ComposeMessage ();
+
+    ustring bdy = "This is test: æøå.\n > testing\ntesting\n...";
+
+    LOG (trace) << "cm: writing utf-8 text to message body: " << bdy;
+    c->body << bdy;
+
+    c->build ();
+    c->finalize ();
+    ustring fn = c->write_tmp ();
+
+    delete c;
+
+    Message m (fn);
+
+    ustring rbdy = m.viewable_text (false);
+
+    BOOST_CHECK_MESSAGE (bdy == rbdy, "message reading produces the same output as compose message input");
+
+    unlink (fn.c_str ());
     teardown ();
   }
 

--- a/tests/test_composed_message.cc
+++ b/tests/test_composed_message.cc
@@ -52,7 +52,38 @@ BOOST_AUTO_TEST_SUITE(Composing)
     unlink (fn.c_str ());
 
     teardown ();
+  }
 
+  BOOST_AUTO_TEST_CASE (compose_test_mem)
+  {
+    using Astroid::ComposeMessage;
+    using Astroid::Message;
+    setup ();
+
+    ComposeMessage * c = new ComposeMessage ();
+
+    ustring bdy = "This is test: æøå.\n > testing\ntesting\n...";
+
+    LOG (trace) << "cm: writing utf-8 text to message body: " << bdy;
+    c->body << bdy;
+
+    c->build ();
+    c->finalize ();
+
+    GMimeStream * ms = g_mime_stream_mem_new ();
+    assert (g_mime_stream_mem_get_owner (GMIME_STREAM_MEM(ms)) == true);
+    c->write (ms);
+
+    Message m (ms);
+
+    delete c;
+    g_object_unref (ms);
+
+    ustring rbdy = m.plain_text (false);
+
+    BOOST_CHECK_MESSAGE (bdy == rbdy, "message reading produces the same output as compose message input");
+
+    teardown ();
   }
 
   BOOST_AUTO_TEST_CASE (compose_test_references)

--- a/tests/test_convert_error.cc
+++ b/tests/test_convert_error.cc
@@ -24,7 +24,7 @@ BOOST_AUTO_TEST_SUITE(Reading)
 
     Astroid::Message m (fname);
 
-    BOOST_CHECK_NO_THROW (m.viewable_text (false));
+    BOOST_CHECK_NO_THROW (m.plain_text (false));
 
     teardown ();
   }
@@ -45,7 +45,7 @@ BOOST_AUTO_TEST_SUITE(Reading)
     quoted  << quoting_a.raw ()
             << endl;
 
-    std::string vt = msg.viewable_text(false);
+    std::string vt = msg.plain_text(false);
     std::stringstream sstr (vt);
     while (sstr.good()) {
       std::string line;

--- a/tests/test_crypto.cc
+++ b/tests/test_crypto.cc
@@ -69,7 +69,7 @@ BOOST_AUTO_TEST_SUITE(GPGEncryption)
     delete c;
 
     Message m (fn);
-    ustring rbdy = m.viewable_text (false);
+    ustring rbdy = m.plain_text (false);
 
     BOOST_CHECK_MESSAGE (bdy == rbdy, "message reading produces the same output as compose message input");
 
@@ -116,7 +116,7 @@ BOOST_AUTO_TEST_SUITE(GPGEncryption)
 
     Message m (fn);
 
-    ustring rbdy = m.viewable_text (false);
+    ustring rbdy = m.plain_text (false);
 
     BOOST_CHECK_MESSAGE (bdy == rbdy, "message reading produces the same output as compose message input");
 
@@ -218,7 +218,7 @@ BOOST_AUTO_TEST_SUITE(GPGEncryption)
     }
 
     /* check that body matches */
-    ustring rbdy = m->viewable_text (false);
+    ustring rbdy = m->plain_text (false);
     BOOST_CHECK_MESSAGE (bdy == rbdy, "message reading produces the same output as compose message input");
 
     /* notmuch thread id */
@@ -251,7 +251,7 @@ BOOST_AUTO_TEST_SUITE(GPGEncryption)
         Db db (Db::DATABASE_READ_ONLY);
         mthread->load_messages (&db);
 
-        BOOST_CHECK_MESSAGE (bdy == mthread->messages[0]->viewable_text (false), "message body matches composed message");
+        BOOST_CHECK_MESSAGE (bdy == mthread->messages[0]->plain_text (false), "message body matches composed message");
 
         tries++;
       }
@@ -321,7 +321,7 @@ BOOST_AUTO_TEST_SUITE(GPGEncryption)
     delete c;
 
     Message m (fn);
-    ustring rbdy = m.viewable_text (false);
+    ustring rbdy = m.plain_text (false);
 
     BOOST_CHECK_MESSAGE (bdy == rbdy, "message reading produces the same output as compose message input");
 

--- a/tests/test_markdown.cc
+++ b/tests/test_markdown.cc
@@ -35,7 +35,7 @@ BOOST_AUTO_TEST_SUITE(Markdown)
     Message m (fn);
 
     /* check plain text part */
-    ustring pbdy = m.viewable_text (false);
+    ustring pbdy = m.plain_text (false);
     BOOST_CHECK_MESSAGE (pbdy == bdy, "plain text matches plain text");
 
     /* check html part */

--- a/tests/test_mime_message.cc
+++ b/tests/test_mime_message.cc
@@ -27,7 +27,7 @@ BOOST_AUTO_TEST_SUITE(Reading)
 
     Message m (fname);
 
-    BOOST_CHECK_NO_THROW (m.viewable_text (true));
+    BOOST_CHECK_NO_THROW (m.plain_text (true));
 
     teardown ();
   }

--- a/tests/test_no_newline_msg.cc
+++ b/tests/test_no_newline_msg.cc
@@ -23,11 +23,12 @@ BOOST_AUTO_TEST_SUITE(Reading)
 
     Message m (fname);
 
-    ustring text =  m.viewable_text(false);
+    ustring text =  m.plain_text(false);
     BOOST_CHECK (text.find ("line-ignored") != ustring::npos);
 
-    ustring html = m.viewable_text(true);
-    BOOST_CHECK (html.find ("line-ignored") != ustring::npos);
+    /* test obsolete: */
+    /* ustring html = m.viewable_text(true); */
+    /* BOOST_CHECK (html.find ("line-ignored") != ustring::npos); */
 
     teardown ();
   }
@@ -46,11 +47,12 @@ BOOST_AUTO_TEST_SUITE(Reading)
 
     Message m (fname);
 
-    ustring text =  m.viewable_text(false);
+    ustring text =  m.plain_text (false);
     BOOST_CHECK (text.find ("line-ignored.com") != ustring::npos);
 
-    ustring html = m.viewable_text(true);
-    BOOST_CHECK (html.find ("line-ignored.com") != ustring::npos);
+    /* test obsolete: */
+    /* ustring html = m.viewable_text(true); */
+    /* BOOST_CHECK (html.find ("line-ignored.com") != ustring::npos); */
 
 
     teardown ();
@@ -66,11 +68,12 @@ BOOST_AUTO_TEST_SUITE(Reading)
 
     Message m (fname);
 
-    ustring text =  m.viewable_text(false);
+    ustring text =  m.plain_text (false);
     BOOST_CHECK (text.find ("line-ignored.com") != ustring::npos);
 
-    ustring html = m.viewable_text(true);
-    BOOST_CHECK (html.find ("line-ignored.com") != ustring::npos);
+    /* test obsolete: */
+    /* ustring html = m.viewable_text(true); */
+    /* BOOST_CHECK (html.find ("line-ignored.com") != ustring::npos); */
 
 
     teardown ();
@@ -86,7 +89,7 @@ BOOST_AUTO_TEST_SUITE(Reading)
 
     Message m (fname);
 
-    ustring text =  m.viewable_text(false, true);
+    ustring text =  m.plain_text (true);
     BOOST_CHECK (text.find ("line-ignored.com") != ustring::npos);
 
 

--- a/tests/test_non_existant_file.cc
+++ b/tests/test_non_existant_file.cc
@@ -72,7 +72,7 @@ BOOST_AUTO_TEST_SUITE(Reading)
     oos->save_to ("tests/mail/test_mail/wont-work.eml");
 
     LOG (test) << "sender: " << oos->sender;
-    LOG (test) << "text: " << oos->viewable_text (false);
+    LOG (test) << "text: " << oos->plain_text (false);
 
     /* these do not seem to be cached */
     LOG (test) << "to: " << AddressList (oos->to()).str();


### PR DESCRIPTION
Following classes updated to use mem:
* EditMessage
* RawMessage
* Message

test in test_composed_message