### PR TITLE
Allow to tag sent messages with same tags as message being replied to

### DIFF
--- a/src/actions/onmessage.cc
+++ b/src/actions/onmessage.cc
@@ -62,13 +62,14 @@ namespace Astroid {
       astroid->actions->emit_message_updated (db, mid);
   }
 
-  AddSentMessage::AddSentMessage (ustring _f, std::vector<ustring> _additional_sent_tags) {
+  AddSentMessage::AddSentMessage (ustring _f, std::vector<ustring> _additional_sent_tags, ustring _parent_mid) {
     fname = _f;
     additional_sent_tags = _additional_sent_tags;
+    parent_mid = _parent_mid;
   }
 
   bool AddSentMessage::doit (Db * db) {
-    mid = db->add_sent_message (fname, additional_sent_tags);
+    mid = db->add_sent_message (fname, additional_sent_tags, parent_mid);
     return true;
   }
 

--- a/src/actions/onmessage.hh
+++ b/src/actions/onmessage.hh
@@ -41,7 +41,7 @@ namespace Astroid {
 
   class AddSentMessage : public Action {
     public:
-      AddSentMessage (ustring fname, std::vector<ustring> additional_sent_tags);
+      AddSentMessage (ustring fname, std::vector<ustring> additional_sent_tags, ustring parent_mid);
 
       virtual bool doit (Db *) override;
       virtual bool undo (Db *) override;
@@ -52,6 +52,7 @@ namespace Astroid {
       ustring fname;
       ustring mid;
       std::vector<ustring> additional_sent_tags;
+      ustring parent_mid;
   };
 
 }

--- a/src/compose_message.cc
+++ b/src/compose_message.cc
@@ -99,8 +99,9 @@ namespace Astroid {
           g_mime_object_get_header_list (GMIME_OBJECT(message)),
           "In-Reply-To");
     } else {
+      ustring tmp = "<" + inreplyto + ">";
       g_mime_object_set_header (GMIME_OBJECT(message), "In-Reply-To",
-          inreplyto.c_str(), NULL);
+          tmp.c_str(), NULL);
     }
   }
 
@@ -671,7 +672,7 @@ namespace Astroid {
     /* add to notmuch with sent tag (on main GUI thread) */
     if (!dryrun && message_sent_result && account->save_sent) {
       astroid->actions->doit (refptr<Action> (
-            new AddSentMessage (save_to.c_str (), account->additional_sent_tags)));
+            new AddSentMessage (save_to.c_str (), account->additional_sent_tags, inreplyto)));
       LOG (info) << "cm: sent message added to db.";
     }
 

--- a/src/db.cc
+++ b/src/db.cc
@@ -335,11 +335,8 @@ namespace Astroid {
             find(additional_sent_tags.begin(), additional_sent_tags.end(), "*") != additional_sent_tags.end()) {
         notmuch_message_t * parent_msg;
         notmuch_database_find_message (nm_db, parent_mid.c_str (), &parent_msg);
-        vector<ustring> parent_tags;
-        for (notmuch_tags_t * tags = notmuch_message_get_tags (parent_msg); notmuch_tags_valid (tags); notmuch_tags_move_to_next (tags)) {
-            parent_tags.push_back (notmuch_tags_get (tags));
-        }
-
+        NotmuchMessage parent_msg_nm = NotmuchMessage(parent_msg);
+        vector<ustring> parent_tags = parent_msg_nm.tags;
         additional_sent_tags.insert (additional_sent_tags.end (), parent_tags.begin (), parent_tags.end ());
     }
 

--- a/src/db.hh
+++ b/src/db.hh
@@ -144,7 +144,7 @@ namespace Astroid {
       static std::vector<ustring> draft_tags;
       static std::vector<ustring> excluded_tags;
 
-      ustring add_sent_message (ustring, std::vector<ustring>);
+      ustring add_sent_message (ustring, std::vector<ustring>, ustring);
       ustring add_draft_message (ustring);
       ustring add_message_with_tags (ustring fname, std::vector<ustring> tags);
       bool remove_message (ustring);

--- a/src/modes/reply_message.cc
+++ b/src/modes/reply_message.cc
@@ -72,7 +72,7 @@ namespace Astroid {
     body = ustring(quoted.str());
 
     references = msg->references + " <" + msg->mid + ">";
-    inreplyto  = "<" + msg->mid + ">";
+    inreplyto  = msg->mid;
 
     /* reply mode combobox */
     reply_revealer->set_reveal_child (true);


### PR DESCRIPTION
This PR introduces special values to `accounts.<account>.additional_sent_tags`, namely `*`  (apply all tags that the message being replied to, if any, has), and `-<tag>` (to exclude tags from being applied). For example, the option "foo,*,-attachment" applies the tag "foo" and any tags the message being replied to has, except for "attachment".