### PR TITLE
fix #317: allow editing the message once it gets available in the db …

### DIFF
--- a/src/compose_message.cc
+++ b/src/compose_message.cc
@@ -662,19 +662,21 @@ namespace Astroid {
     return m_message_sent;
   }
 
-  void ComposeMessage::emit_message_sent (bool res) {
-    m_message_sent.emit (res);
+  void ComposeMessage::emit_message_sent (bool res, ustring save_to) {
+    m_message_sent.emit (res, save_to);
   }
 
   void ComposeMessage::message_sent_event () {
     /* add to notmuch with sent tag (on main GUI thread) */
+    ustring _sto = "";
     if (!dryrun && message_sent_result && account->save_sent) {
       astroid->actions->doit (refptr<Action> (
             new AddSentMessage (save_to.c_str (), account->additional_sent_tags)));
+      _sto = save_to.c_str ();
       LOG (info) << "cm: sent message added to db.";
     }
 
-    emit_message_sent (message_sent_result);
+    emit_message_sent (message_sent_result, _sto);
   }
 
   ComposeMessage::type_message_send_status

--- a/src/compose_message.hh
+++ b/src/compose_message.hh
@@ -114,10 +114,10 @@ namespace Astroid {
 
     public:
       /* message sent */
-      typedef sigc::signal <void, bool> type_message_sent;
+      typedef sigc::signal <void, bool, ustring> type_message_sent;
       type_message_sent message_sent ();
 
-      void emit_message_sent (bool);
+      void emit_message_sent (bool, ustring);
 
       bool message_sent_result;
       void message_sent_event ();

--- a/src/modes/edit_message.hh
+++ b/src/modes/edit_message.hh
@@ -106,8 +106,9 @@ namespace Astroid {
 
       ComposeMessage * sending_message;
       std::atomic<bool> sending_in_progress;
-      void send_message_finished (bool result);
+      void send_message_finished (bool result, ustring fname);
       void update_send_message_status (bool warn, ustring msg);
+      void on_message_added_to_database (Db * db, ustring mid);
 
       /* make a draft message that can be edited */
       void prepare_message ();

--- a/src/modes/thread_view/thread_view.hh
+++ b/src/modes/thread_view/thread_view.hh
@@ -38,6 +38,7 @@ namespace Astroid {
 
   class ThreadView : public Mode {
     friend PageClient;
+    friend EditMessage;
 
     public:
       ThreadView (MainWindow *, bool _edit_mode = false);


### PR DESCRIPTION
…after sending

Since a full thread object isn't set up for the ThreadView there might be some ways to break this, please try. Also, hopefully all functionality which should be off after sending is now off.. (in particular deleting attachments seem to maybe be possible?)

@mxmehl Please take a look.

Related #581 