### PR TITLE
Trash threads in index and view modes

### DIFF
--- a/src/actions/toggle_action.cc
+++ b/src/actions/toggle_action.cc
@@ -72,4 +72,13 @@ namespace Astroid {
   MuteAction::MuteAction (vector<refptr<NotmuchItem>> nmts)
     : ToggleAction (nmts, "muted") {
     }
+
+  TrashAction::TrashAction (refptr<NotmuchItem> nmt)
+    : ToggleAction (nmt, "trash") {
+  }
+
+  TrashAction::TrashAction (vector<refptr<NotmuchItem>> nmts)
+    : ToggleAction (nmts, "trash") {
+  }
+
 }

--- a/src/actions/toggle_action.hh
+++ b/src/actions/toggle_action.hh
@@ -29,5 +29,11 @@ namespace Astroid {
       MuteAction (std::vector<refptr<NotmuchItem>>);
   };
 
+  class TrashAction : public ToggleAction {
+  public:
+    TrashAction (refptr<NotmuchItem>);
+    TrashAction (std::vector<refptr<NotmuchItem>>);
+  };
+
 }
 

--- a/src/db.cc
+++ b/src/db.cc
@@ -335,11 +335,8 @@ namespace Astroid {
             find(additional_sent_tags.begin(), additional_sent_tags.end(), "*") != additional_sent_tags.end()) {
         notmuch_message_t * parent_msg;
         notmuch_database_find_message (nm_db, parent_mid.c_str (), &parent_msg);
-        vector<ustring> parent_tags;
-        for (notmuch_tags_t * tags = notmuch_message_get_tags (parent_msg); notmuch_tags_valid (tags); notmuch_tags_move_to_next (tags)) {
-            parent_tags.push_back (notmuch_tags_get (tags));
-        }
-
+        NotmuchMessage parent_msg_nm = NotmuchMessage(parent_msg);
+        vector<ustring> parent_tags = parent_msg_nm.tags;
         additional_sent_tags.insert (additional_sent_tags.end (), parent_tags.begin (), parent_tags.end ());
     }
 

--- a/src/modes/thread_index/thread_index_list_view.cc
+++ b/src/modes/thread_index/thread_index_list_view.cc
@@ -487,6 +487,11 @@ namespace Astroid {
                              "Toggle archive",
                              bind (&ThreadIndexListView::multi_key_handler, this, MArchive, _1));
 
+    multi_keys.register_key (Key (GDK_KEY_Delete),
+                             "thread_index.multi.trash",
+                             "Toggle trash",
+                             bind (&ThreadIndexListView::multi_key_handler, this, MTrash, _1));
+
     multi_keys.register_key ("S",
                              "thread_index.multi.mark_spam",
                              "Toggle spam",
@@ -875,6 +880,17 @@ namespace Astroid {
           return true;
         });
 
+    keys->register_key (Key (GDK_KEY_Delete), "thread_index.trash",
+        "Toggle 'trash' tag on thread",
+        [&] (Key) {
+          auto thread = get_current_thread ();
+          if (thread) {
+            main_window->actions->doit (refptr<Action>(new TrashAction(thread)));
+          }
+
+          return true;
+        });
+
     keys->register_key (Key (GDK_KEY_asterisk), "thread_index.flag",
         "Toggle 'flagged' tag on thread",
         [&] (Key) {
@@ -1045,6 +1061,7 @@ namespace Astroid {
       case MSpam:
       case MMute:
       case MArchive:
+      case MTrash:
       case MTag:
         {
           vector<refptr<NotmuchItem>> threads;
@@ -1066,6 +1083,10 @@ namespace Astroid {
           switch (maction) {
             case MArchive:
               a = refptr<Action>(new ToggleAction(threads, "inbox"));
+              break;
+
+            case MTrash:
+              a = refptr<Action>(new TrashAction(threads));
               break;
 
             case MFlag:
@@ -1199,6 +1220,14 @@ namespace Astroid {
         {
           if (thread) {
             main_window->actions->doit (refptr<Action>(new ToggleAction(thread, "inbox")));
+          }
+        }
+        break;
+
+      case Trash:
+        {
+          if (thread) {
+            main_window->actions->doit (refptr<Action>(new TrashAction(thread)));
           }
         }
         break;

--- a/src/modes/thread_index/thread_index_list_view.cc
+++ b/src/modes/thread_index/thread_index_list_view.cc
@@ -165,10 +165,20 @@ namespace Astroid {
           , PopupItem::Archive));
     archive_i->set_tooltip_text ("Archive");
 
+    Gtk::Image * trash = Gtk::manage (new Gtk::Image ());
+    trash->set_from_icon_name ("edit-delete", Gtk::ICON_SIZE_LARGE_TOOLBAR);
+    Gtk::MenuItem * trash_i = Gtk::manage (new Gtk::MenuItem (*trash));
+    trash_i->signal_activate ().connect (
+        sigc::bind (
+          sigc::mem_fun (*this, &ThreadIndexListView::popup_activate_generic)
+          , PopupItem::Trash));
+    trash_i->set_tooltip_text ("Send to Trash");
+
     item_popup.attach (*reply_i, 0, 1, 0, 1);
     item_popup.attach (*forward_i, 1, 2, 0, 1);
     item_popup.attach (*flag_i, 2, 3, 0, 1);
     item_popup.attach (*archive_i, 3, 4, 0, 1);
+    item_popup.attach (*trash_i, 4, 5, 0, 1);
 
     Gtk::MenuItem * sep = Gtk::manage (new Gtk::SeparatorMenuItem ());
     item_popup.append (*sep);

--- a/src/modes/thread_index/thread_index_list_view.hh
+++ b/src/modes/thread_index/thread_index_list_view.hh
@@ -85,6 +85,7 @@ namespace Astroid {
         MUnread = 0,
         MFlag,
         MArchive,
+        MTrash,
         MSpam,
         MMute,
         MToggle,
@@ -103,6 +104,7 @@ namespace Astroid {
         Forward,
         Flag,
         Archive,
+        Trash,
         Open,
         OpenNewWindow,
       };

--- a/src/modes/thread_view/thread_view.cc
+++ b/src/modes/thread_view/thread_view.cc
@@ -1385,6 +1385,20 @@ namespace Astroid {
           return true;
         });
 
+    keys.register_key (Key (GDK_KEY_BackSpace),
+        "thread_view.trash_thread",
+        "Toggle 'trash' tag on the whole thread",
+        [&] (Key) {
+
+          if (!edit_mode && focused_message) {
+            if (thread) {
+              main_window->actions->doit (refptr<Action>(new TrashAction(thread)));
+            }
+          }
+
+          return true;
+        });
+
     keys.register_key ("C-P",
         "thread_view.print",
         "Print focused message",
@@ -1568,6 +1582,16 @@ namespace Astroid {
           return true;
         });
 
+    next_multi.register_key (UnboundKey(),
+        "thread_view.multi_next_thread.trash",
+        "Trash and goto next",
+        [&] (Key) {
+          keys.handle ("thread_view.trash_thread");
+          emit_index_action (IA_Next);
+
+          return true;
+        });
+
     next_multi.register_key (Key ("A"),
         "thread_view.multi_next_thread.archive_next_unread_thread",
         "Archive, goto next unread",
@@ -1578,11 +1602,31 @@ namespace Astroid {
           return true;
         });
 
+    next_multi.register_key (UnboundKey(),
+        "thread_view.multi_next_thread.trash_next_unread_thread",
+        "Trash and goto next unread",
+        [&] (Key) {
+          keys.handle ("thread_view.archive_trash");
+          emit_index_action (IA_NextUnread);
+
+          return true;
+        });
+
     next_multi.register_key (Key ("x"),
         "thread_view.multi_next_thread.close",
         "Archive, close",
         [&] (Key) {
           keys.handle ("thread_view.archive_thread");
+          close ();
+
+          return true;
+        });
+
+    next_multi.register_key (Key (GDK_KEY_Delete),
+        "thread_view.multi_next_thread.trash_close",
+        "Trash and close",
+        [&] (Key) {
+          keys.handle ("thread_view.trash_thread");
           close ();
 
           return true;
@@ -1644,6 +1688,27 @@ namespace Astroid {
         "Alias for thread_view.multi_next_thread.close",
         [&] (Key) {
           return next_multi.handle ("thread_view.multi_next_thread.close");
+        });
+
+    keys.register_key (UnboundKey (),
+        "thread_view.trash_then_next",
+        "Alias for thread_view.multi_next_thread.trash",
+        [&] (Key) {
+          return next_multi.handle ("thread_view.multi_next_thread.trash");
+        });
+
+    keys.register_key (UnboundKey (),
+        "thread_view.trash_then_next_unread",
+        "Alias for thread_view.multi_next_thread.trash_next_unread",
+        [&] (Key) {
+          return next_multi.handle ("thread_view.multi_next_thread.trash_next_unread_thread");
+        });
+
+    keys.register_key (Key (GDK_KEY_Delete),
+        "thread_view.trash_and_close",
+        "Alias for thread_view.multi_next_thread.trash_close",
+        [&] (Key) {
+          return next_multi.handle ("thread_view.multi_next_thread.trash_close");
         });
 
     keys.register_key (UnboundKey (),


### PR DESCRIPTION
Just added the ability to trash threads (toggle 'trash' tag) in index and view modes.

Added potential keybindings following the pattern for archiving threads (which I consider to be the closest action in nature) but left most unbound because it looked a bit overkill and didn't want to take over all remaining keys. In the only few places where I bound a key, I used GDK_KEY_Delete (as "d" and "t" were already taken).