### PR TITLE
cm, em: clean up references

### DIFF
--- a/src/compose_message.hh
+++ b/src/compose_message.hh
@@ -19,18 +19,6 @@ namespace bfs = boost::filesystem;
 
 namespace Astroid {
 
-  struct GLibDeleter
-  {
-    constexpr GLibDeleter() = default;
-
-    void operator()(void * object)
-    {
-      g_object_unref(object);
-    }
-  };
-
-  typedef std::unique_ptr<void, GLibDeleter> GLibPointer;
-
   class ComposeMessage : public sigc::trackable {
     public:
       ComposeMessage  ();

--- a/src/modes/edit_message.cc
+++ b/src/modes/edit_message.cc
@@ -336,7 +336,7 @@ namespace Astroid {
         "View raw message",
         [&] (Key) {
           /* view raw source of to be sent message */
-          ComposeMessage * c = make_message ();
+          auto c = make_message ();
 
           GMimeStream * m = g_mime_stream_mem_new ();
           assert (g_mime_stream_mem_get_owner (GMIME_STREAM_MEM(m)) == true);
@@ -345,8 +345,6 @@ namespace Astroid {
           main_window->add_mode (new RawMessage (main_window, refptr<Message>(new UnprocessedMessage(m))));
 
           g_object_unref (m);
-
-          delete c;
 
           return true;
         });
@@ -581,7 +579,7 @@ namespace Astroid {
   bool EditMessage::save_draft () {
     LOG (info) << "em: saving draft..";
     draft_saved = false;
-    ComposeMessage * c = make_draft_message ();
+    auto c = make_draft_message ();
     ustring fname;
 
     bool add_to_notmuch = false;
@@ -593,7 +591,6 @@ namespace Astroid {
       if (!is_directory(ddir)) {
         LOG (error) << "em: no draft directory specified!";
         set_warning ("draft could not be saved, no suitable draft directory for account specified.");
-        delete c;
         return false;
 
       } else {
@@ -616,7 +613,6 @@ namespace Astroid {
             new AddDraftMessage (fname)));
     }
 
-    delete c;
     draft_saved = true;
     return true;
   }
@@ -784,7 +780,7 @@ namespace Astroid {
     }
 
     /* make message */
-    ComposeMessage * c = setup_message ();
+    auto c = setup_message ();
 
     /* set account selector to from address email */
     set_from (c->account);
@@ -819,7 +815,6 @@ namespace Astroid {
     thread_view->load_message_thread (msgt);
 
     g_object_unref (m);
-    delete c;
 
     in_read = false;
   }
@@ -1072,21 +1067,18 @@ namespace Astroid {
 
     on_tv_ready ();
 
-    ComposeMessage * c = make_message ();
+    auto c = make_message ();
 
     if (c == NULL) return false;
 
     if (c->markdown && !c->markdown_success) {
       set_warning ("Cannot send, failed processing markdown: " + UstringUtils::replace (c->markdown_error, "\n", "<br />"));
-      delete c;
       return false;
     }
 
     if (c->encrypt || c->sign) {
       if (!c->encryption_success) {
         set_warning ("Cannot send, failed encrypting: " + UstringUtils::replace (c->encryption_error, "\n", "<br />"));
-
-        delete c;
         return false;
       }
     }
@@ -1112,7 +1104,7 @@ namespace Astroid {
 
     c->send_threaded ();
 
-    sending_message = c;
+    sending_message = std::move (c);
 
     return true;
   }
@@ -1162,15 +1154,14 @@ namespace Astroid {
     message_sending_status_icon.set (pixbuf);
     sending_in_progress.store (false);
 
+    sending_message.reset();
+
+    emit_message_sent_attempt (result_from_sender);
+
     if (result_from_sender && (astroid->config().get<bool> ("mail.close_on_success"))) {
       LOG (info) << "cm: sending successful, auto-closing window";
       close (true);
     }
-
-
-    delete sending_message;
-
-    emit_message_sent_attempt (result_from_sender);
   }
 
   void EditMessage::lock_message_after_send () {
@@ -1179,8 +1170,8 @@ namespace Astroid {
     fields_hide ();
   }
 
-  ComposeMessage * EditMessage::setup_message () {
-    ComposeMessage * c = new ComposeMessage ();
+  std::unique_ptr<ComposeMessage> EditMessage::setup_message () {
+    auto c = std::unique_ptr<ComposeMessage>(new ComposeMessage ());
 
     c->load_message (msg_id, tmpfile_path.c_str());
 
@@ -1194,7 +1185,7 @@ namespace Astroid {
     return c;
   }
 
-  void EditMessage::finalize_message (ComposeMessage * c) {
+  void EditMessage::finalize_message (std::unique_ptr<ComposeMessage> &c) {
     /* these options are not known before setup_message is done, and the
      * new account information has been applied to the editor */
     if (c->account->has_signature && switch_signature->get_active ()) {
@@ -1213,16 +1204,16 @@ namespace Astroid {
     c->finalize ();
   }
 
-  ComposeMessage * EditMessage::make_message () {
+  std::unique_ptr<ComposeMessage> EditMessage::make_message () {
     return make_message (false);
   }
 
-  ComposeMessage * EditMessage::make_draft_message () {
+  std::unique_ptr<ComposeMessage> EditMessage::make_draft_message () {
     return make_message (true);
   }
 
-  ComposeMessage * EditMessage::make_message (bool draft = false) {
-    ComposeMessage * c = setup_message ();
+  std::unique_ptr<ComposeMessage> EditMessage::make_message (bool draft = false) {
+    auto c = setup_message ();
     bool sigstate = c->account->has_signature;
 
     if (draft) {

--- a/src/modes/edit_message.hh
+++ b/src/modes/edit_message.hh
@@ -99,12 +99,13 @@ namespace Astroid {
       std::vector<ustring> attachment_words = { "attach" }; // defined in config
 
       bool send_message ();
-      ComposeMessage * setup_message ();
-      void             finalize_message (ComposeMessage *);
-      ComposeMessage * make_message ();
-      ComposeMessage * make_draft_message ();
+      void finalize_message (std::unique_ptr<ComposeMessage> &);
+      std::unique_ptr<ComposeMessage> setup_message ();
+      std::unique_ptr<ComposeMessage> make_message (bool draft);
+      std::unique_ptr<ComposeMessage> make_message ();
+      std::unique_ptr<ComposeMessage> make_draft_message ();
 
-      ComposeMessage * sending_message;
+      std::unique_ptr<ComposeMessage> sending_message;
       std::atomic<bool> sending_in_progress;
       void send_message_finished (bool result);
       void update_send_message_status (bool warn, ustring msg);
@@ -158,8 +159,6 @@ namespace Astroid {
 
       bool message_sent = false;
       void lock_message_after_send ();
-
-      ComposeMessage * make_message (bool draft);
 
     private:
       void on_from_combo_changed ();


### PR DESCRIPTION
use unique_ptr and close after emitting signals

#591 