### PR TITLE
Cleanup webkit references

### DIFF
--- a/src/db.cc
+++ b/src/db.cc
@@ -335,11 +335,8 @@ namespace Astroid {
             find(additional_sent_tags.begin(), additional_sent_tags.end(), "*") != additional_sent_tags.end()) {
         notmuch_message_t * parent_msg;
         notmuch_database_find_message (nm_db, parent_mid.c_str (), &parent_msg);
-        vector<ustring> parent_tags;
-        for (notmuch_tags_t * tags = notmuch_message_get_tags (parent_msg); notmuch_tags_valid (tags); notmuch_tags_move_to_next (tags)) {
-            parent_tags.push_back (notmuch_tags_get (tags));
-        }
-
+        NotmuchMessage parent_msg_nm = NotmuchMessage(parent_msg);
+        vector<ustring> parent_tags = parent_msg_nm.tags;
         additional_sent_tags.insert (additional_sent_tags.end (), parent_tags.begin (), parent_tags.end ());
     }
 

--- a/src/db.cc
+++ b/src/db.cc
@@ -335,8 +335,11 @@ namespace Astroid {
             find(additional_sent_tags.begin(), additional_sent_tags.end(), "*") != additional_sent_tags.end()) {
         notmuch_message_t * parent_msg;
         notmuch_database_find_message (nm_db, parent_mid.c_str (), &parent_msg);
-        NotmuchMessage parent_msg_nm = NotmuchMessage(parent_msg);
-        vector<ustring> parent_tags = parent_msg_nm.tags;
+        vector<ustring> parent_tags;
+        for (notmuch_tags_t * tags = notmuch_message_get_tags (parent_msg); notmuch_tags_valid (tags); notmuch_tags_move_to_next (tags)) {
+            parent_tags.push_back (notmuch_tags_get (tags));
+        }
+
         additional_sent_tags.insert (additional_sent_tags.end (), parent_tags.begin (), parent_tags.end ());
     }
 

--- a/src/modes/edit_message.cc
+++ b/src/modes/edit_message.cc
@@ -545,8 +545,6 @@ namespace Astroid {
     if (is_regular_file (tmpfile_path)) {
       boost::filesystem::remove (tmpfile_path);
     }
-
-    delete thread_view;
   }
 
   void EditMessage::pre_close () {

--- a/src/modes/edit_message.cc
+++ b/src/modes/edit_message.cc
@@ -212,7 +212,7 @@ namespace Astroid {
     }
 # endif
 
-    thread_view = new ThreadView(main_window, true);
+    thread_view = Gtk::manage(new ThreadView(main_window, true));
     //thread_rev->add (*thread_view);
     editor_box->pack_start (*thread_view, false, false, 2);
 

--- a/src/modes/edit_message.cc
+++ b/src/modes/edit_message.cc
@@ -212,7 +212,7 @@ namespace Astroid {
     }
 # endif
 
-    thread_view = Gtk::manage(new ThreadView(main_window, true));
+    thread_view = new ThreadView(main_window, true);
     //thread_rev->add (*thread_view);
     editor_box->pack_start (*thread_view, false, false, 2);
 
@@ -545,6 +545,12 @@ namespace Astroid {
     if (is_regular_file (tmpfile_path)) {
       boost::filesystem::remove (tmpfile_path);
     }
+
+    delete thread_view;
+  }
+
+  void EditMessage::pre_close () {
+    ((Mode*) thread_view)->pre_close ();
   }
 
   void EditMessage::close (bool force) {

--- a/src/modes/edit_message.hh
+++ b/src/modes/edit_message.hh
@@ -128,6 +128,8 @@ namespace Astroid {
       ThreadView *  thread_view;
       Gtk::Revealer *editor_rev, *thread_rev;
 
+      void pre_close () override;
+
       static  int edit_id; // must be incremented each time a new editor is started
       int     id;          // id of this instance
       time_t  msg_time;

--- a/src/modes/mode.cc
+++ b/src/modes/mode.cc
@@ -35,7 +35,6 @@ namespace Astroid {
 
   void Mode::close (bool force) {
     /* close current page */
-    using std::endl;
     int c = main_window->notebook.page_num (*this);
 
     if (((Mode*) main_window->notebook.get_nth_page (c))->invincible && !force) {

--- a/src/modes/thread_index/thread_index.cc
+++ b/src/modes/thread_index/thread_index.cc
@@ -32,10 +32,10 @@ namespace Astroid {
     list_store = Glib::RefPtr<ThreadIndexListStore>(new ThreadIndexListStore ());
     queryloader.list_store = list_store;
 
-    list_view  = Gtk::manage(new ThreadIndexListView (this, list_store));
+    list_view  = new ThreadIndexListView (this, list_store);
     queryloader.list_view = list_view;
 
-    scroll     = Gtk::manage(new ThreadIndexScrolled (main_window, list_store, list_view));
+    scroll     = new ThreadIndexScrolled (main_window, list_store, list_view);
 
     list_view->set_sort_type (queryloader.sort);
 
@@ -230,10 +230,10 @@ namespace Astroid {
 
     if (new_window) {
       MainWindow * nmw = astroid->open_new_window (false);
-      tv = Gtk::manage(new ThreadView (nmw));
+      tv = new ThreadView (nmw);
       nmw->add_mode (tv);
     } else if (new_tab) {
-      tv = Gtk::manage(new ThreadView (main_window));
+      tv = new ThreadView (main_window);
       main_window->add_mode (tv);
     } else {
       LOG (debug) << "ti: init paned tv";

--- a/src/modes/thread_index/thread_index.cc
+++ b/src/modes/thread_index/thread_index.cc
@@ -32,10 +32,10 @@ namespace Astroid {
     list_store = Glib::RefPtr<ThreadIndexListStore>(new ThreadIndexListStore ());
     queryloader.list_store = list_store;
 
-    list_view  = new ThreadIndexListView (this, list_store);
+    list_view  = Gtk::manage(new ThreadIndexListView (this, list_store));
     queryloader.list_view = list_view;
 
-    scroll     = new ThreadIndexScrolled (main_window, list_store, list_view);
+    scroll     = Gtk::manage(new ThreadIndexScrolled (main_window, list_store, list_view));
 
     list_view->set_sort_type (queryloader.sort);
 
@@ -230,10 +230,10 @@ namespace Astroid {
 
     if (new_window) {
       MainWindow * nmw = astroid->open_new_window (false);
-      tv = new ThreadView (nmw);
+      tv = Gtk::manage(new ThreadView (nmw));
       nmw->add_mode (tv);
     } else if (new_tab) {
-      tv = new ThreadView (main_window);
+      tv = Gtk::manage(new ThreadView (main_window));
       main_window->add_mode (tv);
     } else {
       LOG (debug) << "ti: init paned tv";

--- a/src/modes/thread_index/thread_index.cc
+++ b/src/modes/thread_index/thread_index.cc
@@ -240,7 +240,7 @@ namespace Astroid {
       if (packed == 2) {
         tv = (ThreadView *) pw2;
       } else {
-        tv = new ThreadView (main_window);
+        tv = Gtk::manage(new ThreadView (main_window));
         add_pane (1, tv);
       }
     }

--- a/src/modes/thread_view/thread_view.cc
+++ b/src/modes/thread_view/thread_view.cc
@@ -142,8 +142,6 @@ namespace Astroid {
   ThreadView::~ThreadView () { //
     LOG (debug) << "tv: deconstruct.";
     g_object_unref (websettings);
-    g_object_unref (context);
-    g_object_unref (webview);
   }
 
   void ThreadView::pre_close () {

--- a/src/modes/thread_view/thread_view.cc
+++ b/src/modes/thread_view/thread_view.cc
@@ -112,7 +112,12 @@ namespace Astroid {
           "settings", websettings,
           NULL));
 
+    if (g_object_is_floating (webview)) g_object_ref_sink (webview);
+    g_object_unref (context);
+    g_object_unref (websettings);
+
     gtk_box_pack_start (GTK_BOX (this->gobj ()), GTK_WIDGET (webview), true, true, 0);
+
 
     g_signal_connect (webview, "load-changed",
         G_CALLBACK(ThreadView_on_load_changed),
@@ -141,7 +146,7 @@ namespace Astroid {
 
   ThreadView::~ThreadView () { //
     LOG (debug) << "tv: deconstruct.";
-    g_object_unref (websettings);
+    g_object_unref (webview);
   }
 
   void ThreadView::pre_close () {

--- a/src/modes/thread_view/thread_view.cc
+++ b/src/modes/thread_view/thread_view.cc
@@ -142,6 +142,8 @@ namespace Astroid {
   ThreadView::~ThreadView () { //
     LOG (debug) << "tv: deconstruct.";
     g_object_unref (websettings);
+    g_object_unref (context);
+    g_object_unref (webview);
   }
 
   void ThreadView::pre_close () {

--- a/src/modes/thread_view/thread_view.cc
+++ b/src/modes/thread_view/thread_view.cc
@@ -113,8 +113,6 @@ namespace Astroid {
           NULL));
 
     if (g_object_is_floating (webview)) g_object_ref_sink (webview);
-    g_object_unref (context);
-    g_object_unref (websettings);
 
     gtk_box_pack_start (GTK_BOX (this->gobj ()), GTK_WIDGET (webview), true, true, 0);
 
@@ -146,6 +144,8 @@ namespace Astroid {
 
   ThreadView::~ThreadView () { //
     LOG (debug) << "tv: deconstruct.";
+    g_object_unref (context);
+    g_object_unref (websettings);
     g_object_unref (webview);
   }
 
@@ -1856,7 +1856,7 @@ namespace Astroid {
                   refptr<MessageThread> mt = refptr<MessageThread> (new MessageThread ());
                   mt->add_message (c);
 
-                  ThreadView * tv = new ThreadView (main_window);
+                  ThreadView * tv = Gtk::manage(new ThreadView (main_window));
                   tv->load_message_thread (mt);
 
                   main_window->add_mode (tv);

--- a/src/plugin/manager.cc
+++ b/src/plugin/manager.cc
@@ -323,8 +323,6 @@ namespace Astroid {
    * ThreadViewExtension
    * ************************/
   PluginManager::ThreadViewExtension::ThreadViewExtension (ThreadView * tv) {
-    thread_view  = tv;
-
     if (astroid->plugin_manager->disabled) return;
 
     /* loading extensions for each plugin */

--- a/src/plugin/manager.hh
+++ b/src/plugin/manager.hh
@@ -63,8 +63,6 @@ namespace Astroid {
       };
 
       class ThreadViewExtension : public Extension {
-        private:
-          ThreadView * thread_view;
 
         public:
           ThreadViewExtension (ThreadView * ti);


### PR DESCRIPTION
The destructor for the thread view object didn't release all references, which lead to webkit render processes not being cleaned up after closing the thread view.