### PR TITLE
Set content id of attachments

### DIFF
--- a/src/compose_message.cc
+++ b/src/compose_message.cc
@@ -371,6 +371,7 @@ namespace Astroid {
             g_mime_content_type_get_media_subtype (contentType));
           g_mime_part_set_content (part, data);
           g_mime_part_set_filename (part, a->name.c_str());
+          g_mime_part_set_content_id (part, a->name.c_str());
 
           if (a->dispostion_inline) {
             g_mime_object_set_disposition (GMIME_OBJECT(part), "inline");


### PR DESCRIPTION
The Content-ID is set to the file name.

In this way, when composing HTML message inline images can be included. E.g. when editing markup
```
![This is an inline image](cid:image.jpg)
```
will include `image.jpg` in the text. AFAIK there was no easy way to inline attached images before.

As this happens at send time, the preview will not display the image, though. 