### PR TITLE
Shorten GNUPGHOME length

### DIFF
--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -12,7 +12,7 @@ echo "Source dir: ${SRCDIR}"
 echo "Build dir:  ${BINDIR}"
 
 export NOTMUCH_CONFIG="${BINDIR}/tests/mail/test_config"
-export GNUPGHOME="${BINDIR}/tests/test_home/gnupg"
+export GNUPGHOME="${BINDIR}/gnupg"
 export ASTROID_BUILD_DIR="${BINDIR}"
 
 gpgconf -v --kill all # stop all components


### PR DESCRIPTION
On ppc64el, due to a bit too long GNUPGHOME, gpg socket file name is
too long and gpg fails to create foo1.key in tests/run_test.sh and
the script exits righ away with set -e, leaving the test directory
unproperly set up (missing ui directory, and keys) which makes some tests
fail (generic, theme, crypto)
Here is the Debian bug I opened :
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=909190
https://buildd.debian.org/status/fetch.php?pkg=astroidmail&arch=ppc64el&ver=0.14-1&stamp=1538432617&raw=0
https://buildd.debian.org/status/package.php?p=astroidmail

Some details here about too long socket and gpg :
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=847206#10