### PR TITLE
improve extraction of first names for thread index

### DIFF
--- a/src/db.cc
+++ b/src/db.cc
@@ -643,31 +643,6 @@ namespace Astroid {
      * an unread message in the thread */
     vector<tuple<ustring, bool>> aths;
 
-    /* first check if any messages are unread, if not: just fetch the authors for
-     * the thread without checking each one.
-     *
-     * `get_tags ()` have already been called, so we can safely use `unread` */
-
-    if (!unread) {
-      const char * auths = notmuch_thread_get_authors (nm_thread);
-
-      ustring astr;
-
-      if (auths != NULL) {
-        astr = auths;
-      } else {
-        /* LOG (error) << "nmt: got NULL for authors!"; */
-      }
-
-      std::vector<ustring> maths = VectorUtils::split_and_trim (astr, ",|\\|");
-
-      for (auto & a : maths) {
-        aths.push_back (make_tuple (a, false));
-      }
-
-      return aths;
-    }
-
     /* get messages from thread */
     notmuch_messages_t * qmessages;
     notmuch_message_t  * message;

--- a/src/modes/thread_index/thread_index_list_cell_renderer.cc
+++ b/src/modes/thread_index/thread_index_list_cell_renderer.cc
@@ -478,7 +478,15 @@ namespace Astroid {
 
         ustring an = get<0>(a);
 
-        an = an.substr (0, an.find_first_of (", @"));
+        size_t pos = an.find_first_of (",. @");
+        if (an[pos] == ',' || an[pos] == '.') { // last name, first name format or initial/title.
+            an = an.substr (pos + 1, an.size ());
+            UstringUtils::trim_left (an);
+            pos = an.find_first_of (" @");
+            an = an.substr (0, pos);
+        } else {
+            an = an.substr (0, pos);
+        }
 
         int tlen = static_cast<int>(an.size());
         if ((len + tlen) >= authors_len) {


### PR DESCRIPTION
This is mostly to fix two cases. First where the name is in the format "lastName, firstName", where "lastName" would be extracted before. Second "prefix. firstName lastName", where "prefix" would be extracted before (e.g. title or first initial).

I removed the code that handles the all-read case because notmuch returns a comma-separated list of names, which breaks things if the name itself contains a comma (e.g. "lastName, firstName").