### PR TITLE
Memory, performance, stability improvements

### DIFF
--- a/src/astroid.cc
+++ b/src/astroid.cc
@@ -479,7 +479,7 @@ namespace Astroid {
   }
 
   MainWindow * Astroid::open_new_window (bool open_defaults) {
-    LOG (warn) << "astroid: starting a new window..";
+    LOG (info) << "astroid: starting a new window..";
 
     /* set up a new main window */
 

--- a/src/chunk.cc
+++ b/src/chunk.cc
@@ -296,8 +296,7 @@ namespace Astroid {
         g_mime_stream_filter_add(GMIME_STREAM_FILTER(filter_stream), filter);
         g_object_unref(filter);
 
-        if (charset)
-        {
+        if (charset) {
           LOG (debug) << "charset: " << charset;
           if (std::string(charset) == "utf-8") {
             charset = "UTF-8";

--- a/src/command_bar.cc
+++ b/src/command_bar.cc
@@ -34,10 +34,6 @@ namespace Astroid {
         sigc::mem_fun (*this, &CommandBar::on_entry_activated)
         );
 
-    entry.signal_key_press_event ().connect (
-        sigc::mem_fun (this, &CommandBar::entry_key_press)
-        );
-
     entry.signal_event ().connect ([&] (GdkEvent* event)->bool {
         if (event->type == GDK_KEY_PRESS) {
             return entry_key_press ((GdkEventKey *) event);

--- a/src/db.cc
+++ b/src/db.cc
@@ -129,7 +129,7 @@ namespace Astroid {
                 time << " of maximum " <<
                 db_open_timeout << " seconds.";
 
-        chrono::seconds duration (db_open_delay);
+        chrono::milliseconds duration (db_open_delay);
         this_thread::sleep_for (duration);
 
         time += db_open_delay;
@@ -168,7 +168,7 @@ namespace Astroid {
                 time << " of maximum " <<
                 db_open_timeout << " seconds.";
 
-        chrono::seconds duration (db_open_delay);
+        chrono::milliseconds duration (db_open_delay);
         this_thread::sleep_for (duration);
 
         time += db_open_delay;
@@ -229,7 +229,7 @@ namespace Astroid {
 
       if (nm_db != NULL) {
         LOG (info) << "db: closing db.";
-        notmuch_database_close (nm_db);
+        notmuch_database_destroy (nm_db);
         nm_db = NULL;
       }
 
@@ -686,6 +686,7 @@ namespace Astroid {
         a = Address(ustring (ac)).fail_safe_name ();
       } else {
         /* LOG (error) << "nmt: got NULL for author!"; */
+        notmuch_message_destroy (message);
         continue;
       }
 
@@ -1089,7 +1090,7 @@ namespace Astroid {
             refresh (m);
           } else {
             in_notmuch = false;
-            }
+          }
         });
     return in_notmuch;
   }

--- a/src/db.hh
+++ b/src/db.hh
@@ -197,7 +197,7 @@ namespace Astroid {
       bool closed = false;
 
       const int db_open_timeout = 120; // seconds
-      const int db_open_delay   = 1;   // seconds
+      const int db_open_delay   = 100;   // milliseconds
 
   };
 

--- a/src/modes/keybindings.cc
+++ b/src/modes/keybindings.cc
@@ -436,7 +436,7 @@ namespace Astroid {
             "key: %1 (%2) already exists in map with name: %3, overwriting.",
             k.str (), k.name, r.first->first.name);
 
-        LOG (warn) << wrr;
+        LOG (info) << wrr;
 
         keys.erase (r.first);
         r = keys.insert (KeyBinding (k, t));

--- a/src/modes/log_view.cc
+++ b/src/modes/log_view.cc
@@ -199,8 +199,8 @@ namespace Astroid {
       l = "<span color=\"red\">" + l + "</span>";
     } else if (lvl == logging::trivial::warning) {
       l = "<span color=\"pink\">" + l + "</span>";
-    } else if (lvl == logging::trivial::info) {
-      l = l;
+    //} else if (lvl == logging::trivial::info) {
+    //  l = l;
     } else {
       l = "<span color=\"gray\">" + l + "</span>";
     }

--- a/src/modes/thread_index/query_loader.cc
+++ b/src/modes/thread_index/query_loader.cc
@@ -179,14 +179,14 @@ namespace Astroid {
     notmuch_threads_destroy (threads);
     notmuch_query_destroy (nmquery);
 
+    run = false; // on_thread_changed will not check lock
+
     if (!in_destructor)
       stats_ready.emit (); // update loading status
 
     // catch any remaining entries
     if (!in_destructor)
       queue_has_data.emit ();
-
-    run = false; // on_thread_changed will not check lock
 
     if (!in_destructor)
       deferred_threads_d.emit ();
@@ -220,7 +220,6 @@ namespace Astroid {
         LOG (debug) << "ql: loaded " << loaded_threads << " threads.";
         if (!in_destructor && !list_view->filter_txt.empty()) stats_ready.emit ();
       }
-      db.close ();
     }
   }
 

--- a/src/modes/thread_index/query_loader.cc
+++ b/src/modes/thread_index/query_loader.cc
@@ -14,8 +14,6 @@
 
 # include <notmuch.h>
 
-using std::endl;
-
 namespace Astroid {
   int QueryLoader::nextid = 0;
 
@@ -57,6 +55,9 @@ namespace Astroid {
   QueryLoader::~QueryLoader () {
     LOG (debug) << "ql: destruct.";
     stop (true);
+    list_store->clear ();
+    std::queue<refptr<NotmuchThread>> ().swap (to_list_store);
+    std::queue<ustring> ().swap (changed_threads);
   }
 
   void QueryLoader::start (ustring q) {
@@ -67,11 +68,8 @@ namespace Astroid {
   }
 
   void QueryLoader::stop (bool _in_destructor) {
+    LOG (debug) << "ql (" << id << "): stopping loader...";
     in_destructor = _in_destructor;
-
-    if (run) {
-      LOG (info) << "ql (" << id << "): stopping loader...";
-    }
 
     run = false;
     if (loader_thread.joinable ()) loader_thread.join ();
@@ -82,8 +80,7 @@ namespace Astroid {
     std::lock_guard<std::mutex> lk (to_list_m);
     list_store->clear ();
 
-    while (!to_list_store.empty ())
-      to_list_store.pop ();
+    std::queue<refptr<NotmuchThread>> ().swap (to_list_store);
 
     start (query);
   }
@@ -126,10 +123,9 @@ namespace Astroid {
     if (!in_destructor) stats_ready.emit ();
 
     /* set up query */
-    notmuch_query_t * nmquery;
     notmuch_threads_t * threads;
 
-    nmquery = notmuch_query_create (db.nm_db, query.c_str ());
+    notmuch_query_t * nmquery = notmuch_query_create (db.nm_db, query.c_str ());
     for (ustring & t : db.excluded_tags) {
       notmuch_query_add_tag_exclude (nmquery, t.c_str());
     }
@@ -180,7 +176,7 @@ namespace Astroid {
     }
 
     /* closing query */
-    if (st == NOTMUCH_STATUS_SUCCESS) notmuch_threads_destroy (threads);
+    notmuch_threads_destroy (threads);
     notmuch_query_destroy (nmquery);
 
     if (!in_destructor)
@@ -194,6 +190,8 @@ namespace Astroid {
 
     if (!in_destructor)
       deferred_threads_d.emit ();
+
+    db.close ();
   }
 
   void QueryLoader::to_list_adder () {
@@ -222,6 +220,7 @@ namespace Astroid {
         LOG (debug) << "ql: loaded " << loaded_threads << " threads.";
         if (!in_destructor && !list_view->filter_txt.empty()) stats_ready.emit ();
       }
+      db.close ();
     }
   }
 
@@ -236,6 +235,7 @@ namespace Astroid {
         LOG (debug) << "ql: deferred update of: " << tid;
         on_thread_changed (&db, tid);
       }
+      db.close ();
     }
   }
 

--- a/src/modes/thread_index/thread_index_list_view.cc
+++ b/src/modes/thread_index/thread_index_list_view.cc
@@ -40,6 +40,7 @@ namespace Astroid {
       Glib::RefPtr<ThreadIndexListStore> _list_store,
       ThreadIndexListView * _list_view) : Mode (mw) {
 
+    list_store.clear ();
     list_store = _list_store;
     list_view  = Gtk::manage(_list_view);
 
@@ -93,6 +94,7 @@ namespace Astroid {
 
     thread_index    = _thread_index;
     main_window     = _thread_index->main_window;
+    list_store.clear ();
     list_store      = store;
     filtered_store  = Gtk::TreeModelFilter::create (list_store);
     filtered_store->set_visible_func (sigc::mem_fun (this, &ThreadIndexListView::filter_visible_row));

--- a/src/modes/thread_view/webextension/ae_protocol.cc
+++ b/src/modes/thread_view/webextension/ae_protocol.cc
@@ -139,15 +139,9 @@ namespace Astroid {
     gsize read = 0;
     bool  s    = false;
 
-    AeProtocol::MessageTypes mt;
-
     /* read message size */
     gsize msg_sz = 0;
     s = istream->read_all ((char *) &msg_sz, sizeof (msg_sz), read, reader_cancel);
-
-    if (s && read == 0) {
-      return mt;
-    }
 
     if (!s || read != sizeof (msg_sz)) {
       throw ipc_error ("could not read message size");
@@ -157,6 +151,7 @@ namespace Astroid {
       throw ipc_error ("message exceeds maximum size.");
     }
 
+    AeProtocol::MessageTypes mt;
     s = istream->read_all ((char*) &mt, sizeof (mt), read, reader_cancel);
 
     if (!s || read != sizeof (mt)) {

--- a/src/modes/thread_view/webextension/ae_protocol.cc
+++ b/src/modes/thread_view/webextension/ae_protocol.cc
@@ -139,9 +139,15 @@ namespace Astroid {
     gsize read = 0;
     bool  s    = false;
 
+    AeProtocol::MessageTypes mt;
+
     /* read message size */
     gsize msg_sz = 0;
     s = istream->read_all ((char *) &msg_sz, sizeof (msg_sz), read, reader_cancel);
+
+    if (s && read == 0) {
+      return mt;
+    }
 
     if (!s || read != sizeof (msg_sz)) {
       throw ipc_error ("could not read message size");
@@ -151,7 +157,6 @@ namespace Astroid {
       throw ipc_error ("message exceeds maximum size.");
     }
 
-    AeProtocol::MessageTypes mt;
     s = istream->read_all ((char*) &mt, sizeof (mt), read, reader_cancel);
 
     if (!s || read != sizeof (mt)) {

--- a/src/modes/thread_view/webextension/tvextension.cc
+++ b/src/modes/thread_view/webextension/tvextension.cc
@@ -410,6 +410,7 @@ void AstroidExtension::reader () {/*{{{*/
         break;
 
       default:
+        run = false;
         break; // unknown message
     }
   }

--- a/src/modes/thread_view/webextension/tvextension.hh
+++ b/src/modes/thread_view/webextension/tvextension.hh
@@ -79,8 +79,6 @@ class AstroidExtension {
     };
 
 
-    WebKitDOMNode * container;
-
     void handle_page (AstroidMessages::Page &s);
     ustring part_css;
     bool page_ready = false;


### PR DESCRIPTION
- fixed memory leak in database code -- `notmuch_database_close` closes the connection, but doesn't free the memory; `notmuch_database_destroy` does both
- improved performance by reducing database open wait time from 1 second to 100 milliseconds
- adjusted some log levels (e.g. "warning" when key binding was overwritten by user)
- fixed IPC to not report error when end of stream is reached
- misc memory improvements through explicitly closing things and unconditionally freeing memory
- fixed some code formatting
- fixed some compiler warnings