### PR TITLE
config.cc: Default astroid.notmuch_config to $NOTMUCH_CONFIG

### DIFF
--- a/src/config.cc
+++ b/src/config.cc
@@ -156,7 +156,12 @@ namespace Astroid {
   ptree Config::setup_default_config (bool initial) {
     ptree default_config;
     default_config.put ("astroid.config.version", CONFIG_VERSION);
+
     std::string nm_cfg = path(std_paths.home / path (".notmuch-config")).string();
+    char* nm_env = getenv("NOTMUCH_CONFIG");
+    if (nm_env != NULL) {
+      nm_cfg.assign(nm_env, strlen(nm_env));
+    }
     default_config.put ("astroid.notmuch_config" , nm_cfg);
 
     default_config.put ("astroid.debug.dryrun_sending", false);


### PR DESCRIPTION
By default, notmuch uses the $NOTMUCH_CONFIG environment variable in
order to find its config file. This commit makes astroid's default
config generator use this variable in order to populate the
astroid.notmuch_config setting.