### PR TITLE
Fix encryption error with gmime3

### DIFF
--- a/src/crypto.cc
+++ b/src/crypto.cc
@@ -248,7 +248,7 @@ namespace Astroid {
         mo,
         sign,
         userid.c_str (),
-        GMIME_ENCRYPT_NONE,
+        always_trust?GMIME_ENCRYPT_ALWAYS_TRUST:GMIME_ENCRYPT_NONE,
         recpa,
         err);
 


### PR DESCRIPTION
This makes `gpg.always_trust` work again with gmime3. Solution taken from issue #638

I consider this worth to trigger a new version or at least a backport to the latest release since it seems that gmime3 is now installed by default on Arch. At least I did not conciously install gmime3 on my laptop, and after a recent rebuild of astroid encryption suddenly failed with "Failed encrypting: Encryption failed: Unusable public key".