### PR TITLE
fix incomplete markdown rendering and warnings, clean compose_message.cc a bit

### DIFF
--- a/src/compose_message.cc
+++ b/src/compose_message.cc
@@ -172,10 +172,6 @@ namespace Astroid {
       GMimePart * html = g_mime_part_new_with_type ("text", "html");
       g_mime_object_set_content_type_parameter ((GMimeObject *) html, "charset", astroid->config().get<string>("editor.charset").c_str());
 
-      if (astroid->config().get<bool> ("mail.format_flowed")) {
-        g_mime_object_set_content_type_parameter ((GMimeObject *) html, "format", "flowed");
-      }
-
       GMimeStream * contentStream = g_mime_stream_mem_new();
 
       /* pipe through markdown to html generator */

--- a/src/compose_message.cc
+++ b/src/compose_message.cc
@@ -225,7 +225,7 @@ namespace Astroid {
 
           LOG (debug) << "cm: md: got html: " << _html;
 
-          contentStream = g_mime_stream_mem_new_with_buffer(_html.c_str(), _html.size());
+          contentStream = g_mime_stream_mem_new_with_buffer(_html.c_str(), _html.bytes());
         }
 
         g_spawn_close_pid (pid);


### PR DESCRIPTION
* fix incomplete markdown rendering (#585)
* for other changes see commit messages
* compiles using `CMAKE_BUILD_TYPE`s `Debug` and `Release`
* changed code compiles without warnings with `-Wall` and `-O0 -ggdb` or `-O3`
* not tested with gmime-2