### PR TITLE
Support plaforms without abstract unix sockets

### DIFF
--- a/src/modes/thread_view/page_client.cc
+++ b/src/modes/thread_view/page_client.cc
@@ -115,15 +115,25 @@ namespace Astroid {
 
     /* set up unix socket */
     LOG (warn) << "pc: id: " << id;
+	refptr<Gio::UnixSocketAddress> addr;
 
-    socket_addr = ustring::compose ("%1/sockets/astroid.%2.%3.%4",
-        astroid->standard_paths ().runtime_dir.c_str(),
-        getpid(),
-        id,
-        UstringUtils::random_alphanumeric (30));
+	if(Gio::UnixSocketAddress::abstract_names_supported ()) {
+		socket_addr = ustring::compose ("%1/sockets/astroid.%2.%3.%4",
+			astroid->standard_paths ().runtime_dir.c_str(),
+			getpid(),
+			id,
+			UstringUtils::random_alphanumeric (30));
 
-    refptr<Gio::UnixSocketAddress> addr = Gio::UnixSocketAddress::create (socket_addr,
-        Gio::UNIX_SOCKET_ADDRESS_ABSTRACT);
+		addr = Gio::UnixSocketAddress::create (socket_addr,
+				Gio::UNIX_SOCKET_ADDRESS_ABSTRACT);
+	} else {
+		socket_addr = ustring::compose ("/tmp/astroid.%1.%2.%3",
+				getpid(),
+				id,
+				UstringUtils::random_alphanumeric (30));
+addr = Gio::UnixSocketAddress::create (socket_addr,
+			Gio::UNIX_SOCKET_ADDRESS_PATH);
+	}
 
     refptr<Gio::SocketAddress> eaddr;
 

--- a/src/modes/thread_view/webextension/tvextension.cc
+++ b/src/modes/thread_view/webextension/tvextension.cc
@@ -146,8 +146,14 @@ AstroidExtension::AstroidExtension (
   gsize sz;
   const char * caddr = g_variant_get_string ((GVariant *) gaddr, &sz);
 
-  refptr<Gio::UnixSocketAddress> addr = Gio::UnixSocketAddress::create (caddr,
-      Gio::UNIX_SOCKET_ADDRESS_ABSTRACT);
+  refptr<Gio::UnixSocketAddress> addr;
+  if(Gio::UnixSocketAddress::abstract_names_supported ()) {
+	addr = Gio::UnixSocketAddress::create (caddr,
+		Gio::UNIX_SOCKET_ADDRESS_ABSTRACT);
+  } else {
+	refptr<Gio::UnixSocketAddress> addr = Gio::UnixSocketAddress::create (caddr,
+		Gio::UNIX_SOCKET_ADDRESS_PATH);
+  }
 
   /* connect to socket */
   cli = Gio::SocketClient::create ();


### PR DESCRIPTION
This is a fix to #646 that should allow functionality on macOS and FreeBSD. Sorry if the code style wasn't up to scratch.