### PR TITLE
Add get_queries() extension method

### DIFF
--- a/src/astroid.cc
+++ b/src/astroid.cc
@@ -493,6 +493,17 @@ namespace Astroid {
         mw->add_mode (s);
       }
 
+# ifndef DISABLE_PLUGINS
+      auto queries = plugin_manager->astroid_extension->get_queries ();
+      LOG (info) << "extension queries: " << queries.size();
+      if (queries.size() > 0) {
+        for (auto query : queries) {
+          Mode * ti = new ThreadIndex(mw, query.second, query.first);
+          ti->invincible = true;
+          mw->add_mode(ti);
+        }
+      } else {
+# endif
       ptree qpt = config ("startup.queries");
 
       for (const auto &kv : qpt) {
@@ -504,6 +515,9 @@ namespace Astroid {
         ti->invincible = true; // set startup queries to be invincible
         mw->add_mode (ti);
       }
+# ifndef DISABLE_PLUGINS
+      }
+# endif
 
       mw->set_active (0);
     }

--- a/src/plugin/astroid_activatable.c
+++ b/src/plugin/astroid_activatable.c
@@ -158,6 +158,26 @@ astroid_activatable_get_tag_colors (AstroidActivatable * activatable, const char
 }
 
 /**
+ * astroid_activatable_get_queries:
+ * @activatable: A #AstroidActivatable.
+ *
+ * Returns: (element-type utf8) (transfer container): List of lists containing a name and a query.
+ */
+GList *
+astroid_activatable_get_queries (AstroidActivatable * activatable)
+{
+    AstroidActivatableInterface *iface;
+
+    if (!ASTROID_IS_ACTIVATABLE (activatable)) return NULL;
+
+    iface = ASTROID_ACTIVATABLE_GET_IFACE (activatable);
+    if (iface->get_queries)
+        return iface->get_queries (activatable);
+
+  return NULL;
+}
+
+/**
  * astroid_activatable_process:
  * @activatable: A #AstroidActivatable.
  * @fname: A #utf8.

--- a/src/plugin/astroid_activatable.h
+++ b/src/plugin/astroid_activatable.h
@@ -28,6 +28,7 @@ struct _AstroidActivatableInterface
   const char * (*get_user_agent) (AstroidActivatable * activatable);
   const char * (*generate_mid) (AstroidActivatable * activatable);
   GList *      (*get_tag_colors) (AstroidActivatable * activatable, const char * tag, const char * bg);
+  GList *      (*get_queries) (AstroidActivatable * activatable);
   GMimeStream * (*process) (AstroidActivatable * activatable, const char * fname);
 
 };
@@ -43,6 +44,7 @@ void astroid_activatable_update_state (AstroidActivatable *activatable);
 const char * astroid_activatable_get_user_agent (AstroidActivatable * activatable);
 const char * astroid_activatable_generate_mid (AstroidActivatable * activatable);
 GList *      astroid_activatable_get_tag_colors (AstroidActivatable * activatable, const char * tag, const char * bg);
+GList *      astroid_activatable_get_queries (AstroidActivatable * activatable);
 GMimeStream * astroid_activatable_process (AstroidActivatable * activatable, const char * fname);
 
 G_END_DECLS

--- a/src/plugin/manager.cc
+++ b/src/plugin/manager.cc
@@ -241,6 +241,32 @@ namespace Astroid {
     return clrs;
   }
 
+  std::vector<std::pair<ustring, ustring>> PluginManager::AstroidExtension::get_queries () {
+    std::vector<std::pair<ustring, ustring>> queries = {};
+
+    if (!active || astroid->plugin_manager->disabled) return queries;
+
+    for (PeasPluginInfo * p : astroid->plugin_manager->astroid_plugins) {
+      PeasExtension * pe = peas_extension_set_get_extension (extensions, p);
+
+      GList * list = astroid_activatable_get_queries (ASTROID_ACTIVATABLE(pe));
+
+      if (list != NULL) {
+        std::vector<ustring> _list = Glib::ListHandler<ustring>::list_to_vector (list, Glib::OWNERSHIP_NONE);
+        if (_list.size() % 2 != 0) {
+          return queries;
+        }
+        for (auto it = _list.begin(); it != _list.end(); it += 2) {
+          queries.push_back(std::make_pair(*it, *(it+1)));
+        }
+
+        g_list_free(list);
+      }
+    }
+
+    return queries;
+  }
+
   GMimeStream * PluginManager::AstroidExtension::process (
       const char * fname) {
     if (!active || astroid->plugin_manager->disabled) return NULL;

--- a/src/plugin/manager.hh
+++ b/src/plugin/manager.hh
@@ -45,6 +45,7 @@ namespace Astroid {
           bool get_user_agent (ustring &);
           bool generate_mid (ustring &);
           std::pair<ustring, ustring> get_tag_colors (ustring tag, ustring bg);
+          std::vector<std::pair<ustring, ustring>> get_queries ();
           GMimeStream * process (const char * fname);
       };
 


### PR DESCRIPTION
This patch adds a way to programmatically generate queries on startup.
This is done by adding a new method named "get_queries" to the
astroid_activatable interface.

Closes https://github.com/astroidmail/astroid/issues/614.

Since I still don't know how to write C++<->python interop code, I took what I feel is a particularly hackish approach. Indeed, I made the python plugin return a `[name, query, name, query…]` list instead of a list of tuples or even a map because I couldn't figure out how to have the C++ side deal with objects or lists of lists. Any help improving this part of the code is more than welcome.