### PR TITLE
Set black text colour in email body

### DIFF
--- a/ui/part.scss
+++ b/ui/part.scss
@@ -18,6 +18,7 @@
 
 body {
   background-color: white !important;
+  color: black;
   overflow-x: auto;
   overflow-y: hidden;
   word-break: break-word;


### PR DESCRIPTION
`part.scss` sets the background colour of email bodies to be white, but didn't specify a foreground colour, causing emails to be unreadable when using a dark GTK theme. Fixes #662.