### PR TITLE
remove minimum width for command bar

### DIFF
--- a/src/command_bar.cc
+++ b/src/command_bar.cc
@@ -27,7 +27,6 @@ namespace Astroid {
 
     hbox.pack_start (mode_label, false, false, 5);
     hbox.pack_start (entry, true, true, 5);
-    entry.set_size_request (600, -1);
     add(hbox);
 
     entry.signal_activate ().connect (

--- a/src/command_bar.cc
+++ b/src/command_bar.cc
@@ -27,6 +27,7 @@ namespace Astroid {
 
     hbox.pack_start (mode_label, false, false, 5);
     hbox.pack_start (entry, true, true, 5);
+    entry.set_max_width_chars(600);
     add(hbox);
 
     entry.signal_activate ().connect (


### PR DESCRIPTION
Following on #667, I suggest removing this minimum width setting completely as Astroid already has a default size defined here:
https://github.com/astroidmail/astroid/blob/35660d486bed3c856603dcff8e8b52153e8e8da9/src/main_window.cc#L105

As a reference I found this: https://valadoc.org/gtk+-3.0/Gtk.Widget.set_size_request.html
> In most cases, set_default_size is a better choice for toplevel windows than this function; setting the default size will still allow users to shrink the window.

Thank you!