### PR TITLE
Use colors with the correct gtk state flag

### DIFF
--- a/src/modes/thread_index/thread_index_list_cell_renderer.cc
+++ b/src/modes/thread_index/thread_index_list_cell_renderer.cc
@@ -108,12 +108,12 @@ namespace Astroid {
     }
 
     render_background (cr, widget, background_area, flags);
-    render_date (cr, widget, cell_area); // returns height
+    render_date (cr, widget, cell_area, flags); // returns height
 
     if (thread->total_messages > 1)
-      render_message_count (cr, widget, cell_area);
+      render_message_count (cr, widget, cell_area, flags);
 
-    render_authors (cr, widget, cell_area);
+    render_authors (cr, widget, cell_area, flags);
 
     tags_width = render_tags (cr, widget, cell_area, flags); // returns width
     subject_start = tags_start + tags_width / Pango::SCALE + ((tags_width > 0) ? padding : 0);
@@ -383,7 +383,8 @@ namespace Astroid {
   int ThreadIndexListCellRenderer::render_date ( // {{{
       const ::Cairo::RefPtr< ::Cairo::Context>&cr,
       Gtk::Widget &widget,
-      const Gdk::Rectangle &cell_area ) {
+      const Gdk::Rectangle &cell_area,
+      Gtk::CellRendererState flags) {
 
     ustring date = Date::pretty_print (thread->newest_date);
 
@@ -393,7 +394,12 @@ namespace Astroid {
 
     /* set color */
     Glib::RefPtr<Gtk::StyleContext> stylecontext = widget.get_style_context();
-    Gdk::RGBA color = stylecontext->get_color(Gtk::STATE_FLAG_NORMAL);
+    Gdk::RGBA color;
+    if ((flags & Gtk::CELL_RENDERER_SELECTED) != 0) {
+        color = stylecontext->get_color(Gtk::STATE_FLAG_SELECTED);
+    } else {
+        color = stylecontext->get_color(Gtk::STATE_FLAG_NORMAL);
+    }
     cr->set_source_rgb (color.get_red(), color.get_green(), color.get_blue());
 
     /* align in the middle */
@@ -414,7 +420,8 @@ namespace Astroid {
   void ThreadIndexListCellRenderer::render_message_count ( // {{{
       const ::Cairo::RefPtr< ::Cairo::Context>&cr,
       Gtk::Widget &widget,
-      const Gdk::Rectangle &cell_area ) {
+      const Gdk::Rectangle &cell_area,
+      Gtk::CellRendererState flags) {
 
 # define BUFLEN 24
     char buf[BUFLEN];
@@ -427,7 +434,12 @@ namespace Astroid {
 
     /* set color */
     Glib::RefPtr<Gtk::StyleContext> stylecontext = widget.get_style_context();
-    Gdk::RGBA color = stylecontext->get_color(Gtk::STATE_FLAG_NORMAL);
+    Gdk::RGBA color;
+    if ((flags & Gtk::CELL_RENDERER_SELECTED) != 0) {
+        color = stylecontext->get_color(Gtk::STATE_FLAG_SELECTED);
+    } else {
+        color = stylecontext->get_color(Gtk::STATE_FLAG_NORMAL);
+    }
     cr->set_source_rgb (color.get_red(), color.get_green(), color.get_blue());
 
     /* align in the middle */
@@ -446,7 +458,8 @@ namespace Astroid {
   void ThreadIndexListCellRenderer::render_authors ( // {{{
       const ::Cairo::RefPtr< ::Cairo::Context>&cr,
       Gtk::Widget &widget,
-      const Gdk::Rectangle &cell_area ) {
+      const Gdk::Rectangle &cell_area,
+      Gtk::CellRendererState flags) {
 
     /* format authors string */
     ustring authors;
@@ -533,7 +546,12 @@ namespace Astroid {
 
     /* set color */
     Glib::RefPtr<Gtk::StyleContext> stylecontext = widget.get_style_context();
-    Gdk::RGBA color = stylecontext->get_color(Gtk::STATE_FLAG_NORMAL);
+    Gdk::RGBA color;
+    if ((flags & Gtk::CELL_RENDERER_SELECTED) != 0) {
+        color = stylecontext->get_color(Gtk::STATE_FLAG_SELECTED);
+    } else {
+        color = stylecontext->get_color(Gtk::STATE_FLAG_NORMAL);
+    }
     cr->set_source_rgb (color.get_red(), color.get_green(), color.get_blue());
 
     /* align in the middle */

--- a/src/modes/thread_index/thread_index_list_cell_renderer.hh
+++ b/src/modes/thread_index/thread_index_list_cell_renderer.hh
@@ -127,17 +127,20 @@ namespace Astroid {
       int render_date (
           const ::Cairo::RefPtr< ::Cairo::Context>&cr,
           Gtk::Widget &widget,
-          const Gdk::Rectangle &cell_area );
+          const Gdk::Rectangle &cell_area,
+          Gtk::CellRendererState flags );
 
       void render_message_count (
           const ::Cairo::RefPtr< ::Cairo::Context>&cr,
           Gtk::Widget &widget,
-          const Gdk::Rectangle &cell_area );
+          const Gdk::Rectangle &cell_area,
+          Gtk::CellRendererState flags );
 
       void render_authors (
           const ::Cairo::RefPtr< ::Cairo::Context>&cr,
           Gtk::Widget &widget,
-          const Gdk::Rectangle &cell_area );
+          const Gdk::Rectangle &cell_area,
+          Gtk::CellRendererState flags );
 
       void render_delimiter (
           const ::Cairo::RefPtr< ::Cairo::Context>&cr,


### PR DESCRIPTION
This applies the correct default font color for selected items (white on blue instead of black on blue) which make them more readable.

Maybe the subject colors could be also handled this way (didn't touch them since they are configurable).