### PR TITLE
End test email message bodies with a trailing newline

### DIFF
--- a/tests/test_composed_message.cc
+++ b/tests/test_composed_message.cc
@@ -32,7 +32,7 @@ BOOST_AUTO_TEST_SUITE(Composing)
 
     ComposeMessage * c = new ComposeMessage ();
 
-    ustring bdy = "This is test: æøå.\n > testing\ntesting\n...";
+    ustring bdy = "This is test: æøå.\n > testing\ntesting\n...\n";
 
     LOG (trace) << "cm: writing utf-8 text to message body: " << bdy;
     c->body << bdy;
@@ -62,7 +62,7 @@ BOOST_AUTO_TEST_SUITE(Composing)
 
     ComposeMessage * c = new ComposeMessage ();
 
-    ustring bdy = "This is test: æøå.\n > testing\ntesting\n...";
+    ustring bdy = "This is test: æøå.\n > testing\ntesting\n...\n";
 
     LOG (trace) << "cm: writing utf-8 text to message body: " << bdy;
     c->body << bdy;
@@ -193,7 +193,7 @@ BOOST_AUTO_TEST_SUITE(Composing)
 
     ComposeMessage * c = new ComposeMessage ();
 
-    ustring bdy = "This is test: æøå.\n > testing\ntesting\n...";
+    ustring bdy = "This is test: æøå.\n > testing\ntesting\n...\n";
 
     LOG (trace) << "cm: writing utf-8 text to message body: " << bdy;
     c->body << bdy;


### PR DESCRIPTION
Test regressed under gmime 3.2.3, because of the change in jstedfast/gmime@2dd1be81555d787ff1ff03b11e5cb4b9e81630d6

A trailing newline was added to the text/plain message body in the test, causing the round-trip comparison to fail.

Fixes: #676