### PR TITLE
GitHub action to build on Debian & Ubuntu

### DIFF
--- a/.github/workflows/ci-debian-build-test.yml
+++ b/.github/workflows/ci-debian-build-test.yml
@@ -1,0 +1,72 @@
+---
+name: "CI: Debian & Derivatives"
+on:
+  - push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    container: ${{ matrix.container }}
+    strategy:
+      fail-fast: false
+      matrix:
+        container:
+          - 'debian:sid'
+          - 'debian:stable'
+          - 'ubuntu:devel'
+          - 'ubuntu:focal'
+          - 'ubuntu:bionic'
+    timeout-minutes: 15
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v2
+      - name: Install build dependencies
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          echo 'APT::Install-Recommends "false";' > /etc/apt/apt.conf.d/80-no-recommends
+          apt-get update
+          apt-get -y upgrade
+          apt-get -y install \
+            cmake \
+            cmark \
+            gnupg \
+            libboost-date-time-dev \
+            libboost-filesystem-dev \
+            libboost-log-dev \
+            libboost-program-options-dev \
+            libboost-system-dev \
+            libboost-test-dev \
+            libboost-thread-dev \
+            libgirepository1.0-dev \
+            libglibmm-2.4-dev \
+            libgmime-3.0-dev \
+            libgtkmm-3.0-dev \
+            libnotmuch-dev \
+            libpeas-dev \
+            libprotobuf-dev \
+            libsass-dev \
+            libsoup2.4-dev \
+            libvte-2.91-dev \
+            libwebkit2gtk-4.0-dev \
+            ninja-build \
+            notmuch \
+            pkg-config \
+            protobuf-compiler \
+            python3-gi \
+            w3m \
+            xauth \
+            xvfb
+          # Older releases don't have scdoc, but should have ronn
+          apt-get -y install scdoc || apt-get -y install ruby-ronn
+      - name: "CMake: Configure"
+        run: cmake -H. -Bbuild -GNinja
+      - name: "CMake: Build"
+        run: cmake --build build
+      - name: Run Tests
+        env:
+          HOME: /tmp/home
+          LC_ALL: C.UTF-8
+        run: |
+          mkdir -p $HOME
+          cd build
+          xvfb-run ctest --output-on-failure


### PR DESCRIPTION
I'd like to think #676 could have been caught sooner, if there was continuous integration testing. And presumably other changes that have caused build failures in master could have been caught sooner.

Here's a [GitHub Actions](https://help.github.com/en/actions) config to run builds on a range of Debian and Ubuntu releases. You could easily add other distributions using the same approach.

This will need some maintenance over time:
1. Updating the list of releases to test on. Ubuntu devel points to the current development release, but the other supported LTSs are named.
1. Updating build dependencies. This might require hacks like the `apt-get ... || apt-get ...` I used here. In the future `apt-get satisfy` will be a nice solution for that kind of thing, but it's only available from apt 1.9.0.

You can see logs of this build [here](https://github.com/stefanor/astroid/actions/runs/99741389). They're fail on newer releases due to #676, but [here](https://github.com/stefanor/astroid/actions/runs/99741390) is an example with #685 merged, so they all pass.

I started with Travis CI: [Branch](https://github.com/stefanor/astroid/compare/travis-ci?expand=1), [Status](https://travis-ci.org/github/stefanor/astroid). But I could only test on one Ubuntu LTS release, there. Which means it'd take a lot longer to notice regressions caused by changes in dependency libraries. Testing on Debian unstable / Ubuntu devel releases is a good way to catch these sooner.