### PR TITLE
ql: Default initialize threads to NULL.

### DIFF
--- a/src/modes/thread_index/query_loader.cc
+++ b/src/modes/thread_index/query_loader.cc
@@ -123,7 +123,7 @@ namespace Astroid {
     if (!in_destructor) stats_ready.emit ();
 
     /* set up query */
-    notmuch_threads_t * threads;
+    notmuch_threads_t * threads = NULL;
 
     notmuch_query_t * nmquery = notmuch_query_create (db.nm_db, query.c_str ());
     for (ustring & t : db.excluded_tags) {


### PR DESCRIPTION
The function notmuch_query_search_threads() only [sets the pointer on success](https://github.com/notmuch/notmuch/blob/2b62ca2e3b786beca8d89fa737bda0b49faa638d/lib/query.cc#L532-L533).  Not initializing the pointer could result in an abort or segfault in notmuch_threads_destroy() due to it pointing to whatever was previously on the stack.