### PR TITLE
Fix gmime assertions being triggered by invalid addresses

### DIFF
--- a/src/utils/address.cc
+++ b/src/utils/address.cc
@@ -32,16 +32,17 @@ namespace Astroid {
 
     _valid = true;
 
-    if (internet_address_list_length (list) > 1) {
-      LOG (error) << "address: more than one address in list!";
+    if (!IS_INTERNET_ADDRESS_LIST (list) || internet_address_list_length (list) < 1) {
+      LOG (error) << "address: no address in string.";
       _valid = false;
       _email = str;
-      g_object_unref (list);
+      if (list != NULL)
+        g_object_unref (list);
       return;
     }
 
-    if (internet_address_list_length (list) < 1) {
-      LOG (error) << "address: no address in string.";
+    if (internet_address_list_length (list) > 1) {
+      LOG (error) << "address: more than one address in list!";
       _email = str;
       _valid = false;
       g_object_unref (list);


### PR DESCRIPTION
In the console, I am frequently seeing the following assertions being triggered.
```
(astroid:1774218): gmime-CRITICAL **: 18:25:20.896: internet_address_list_length: assertion 'IS_INTERNET_ADDRESS_LIST (list)' failed
(astroid:1774218): gmime-CRITICAL **: 18:25:20.896: internet_address_list_length: assertion 'IS_INTERNET_ADDRESS_LIST (list)' failed
[18:25:20] [0x00007fffc2d6c6c0] [M] [error] address: no address in string.
```

Silence this by checking `IS_INTERNET_ADDRESS_LIST` before calling `internet_address_list_length`.