### PR TITLE
Remove enable-frame-flattening and iframe for message body

### DIFF
--- a/src/modes/thread_view/theme.hh
+++ b/src/modes/thread_view/theme.hh
@@ -27,7 +27,7 @@ namespace Astroid {
       static ustring       thread_view_css;
       static ustring       part_css;
       const char * STYLE_NAME = "STYLE";
-      const int THEME_VERSION = 5;
+      const int THEME_VERSION = 6;
 
     private:
       bool check_theme_version (bfs::path);

--- a/src/modes/thread_view/thread_view.cc
+++ b/src/modes/thread_view/thread_view.cc
@@ -99,7 +99,6 @@ namespace Astroid {
         "enable-xss-auditor", TRUE,
         "media-playback-requires-user-gesture", TRUE,
         "zoom-text-only", TRUE,
-        "enable-frame-flattening", TRUE,
 # if (DEBUG || DEBUG_WEBKIT)
         "enable-developer-extras", TRUE,
 # endif

--- a/src/modes/thread_view/webextension/tvextension.hh
+++ b/src/modes/thread_view/webextension/tvextension.hh
@@ -124,7 +124,7 @@ class AstroidExtension {
         const AstroidMessages::Message::Chunk &c,
         WebKitDOMHTMLElement * span_body);
 
-    void set_iframe_src (ustring, ustring, ustring);
+    void set_body_message (ustring, ustring, ustring);
 
     void create_sibling_part (
         /* const AstroidMessages::Message &message, */

--- a/ui/part.scss
+++ b/ui/part.scss
@@ -1,4 +1,4 @@
-/* ui-version: 5 (do not change when modifying theme for yourself) */
+/* ui-version: 6 (do not change when modifying theme for yourself) */
 /* Fonts */
 @if not(global-variable-exists(font-base-size)) {
   $font-base-size: 16px !global;
@@ -14,20 +14,6 @@
 
 @if not(global-variable-exists(font-family-default)) {
   $font-family-default: $font-sans !global;
-}
-
-body {
-  background-color: white !important;
-  color: black;
-  overflow-x: auto;
-  overflow-y: hidden;
-  word-break: break-word;
-  word-wrap: break-word;
-
-  font-size: $font-base-size;
-  font-family: $font-family-default;
-  margin: 0 0 0 0;
-  text-align: left;
 }
 
 .search_coloring *::selection {

--- a/ui/thread-view.html
+++ b/ui/thread-view.html
@@ -1,4 +1,4 @@
-<!-- ui-version: 5 (do not change when modifying theme for yourself) -->
+<!-- ui-version: 6 (do not change when modifying theme for yourself) -->
 <html>
 <head>
   <title>Astroid</title>
@@ -57,7 +57,7 @@
 </div>
 
 <div id="body_template" class="body_part">
-  <iframe class="body_iframe" sandbox srcdoc=""></iframe>
+  <div class="body_message"></div>
 </div>
 
 

--- a/ui/thread-view.scss
+++ b/ui/thread-view.scss
@@ -1,4 +1,4 @@
-/* ui-version: 5 (do not change when modifying theme for yourself) */
+/* ui-version: 6 (do not change when modifying theme for yourself) */
 /* Variables */
 @if not(global-variable-exists(background-color)) {
   $background-color: #ccc !global;
@@ -393,7 +393,7 @@ body:not(.nohide) .email.hide .header_container .avatar {
     }
 }
 
-iframe {
+.body_message {
   border: none;
   width: 100%;
   text-align: left;


### PR DESCRIPTION
Consider this a WIP / broken change.  It's enough to fix issues relating to the removal of frame flattening in #720 for me that does not detriment the ability for Astroid to function.  Based on the comments in the code, there looks to be a very real reason for using iframes for the message content, however I wasn't able to get it to render correctly with the very little knowledge and means of using the C++ API of WebKitGTK, and I can't possibly devote any more time to working out the control flow of the various parts (it's difficult enough stepping through two or more gdb sessions for all the separate processes spawned just to view an email thread).

Maybe this might inspire someone to make a proper fix. :-)

---

As of WebKitGTK 2.40, enable-frame-flattening is no longer supported, the property does nothing, resulting in all messages in the thread viewer being cut off at around 150px, making all messages longer than 2-3 lines unreadable.

I initially had a look into seeing whether the iframe height could be set programmatically with `webkit_dom_html_iframe_element_set_height` from the content of the iframe via `webkit_dom_element_get_scroll_height`. However nothing worked at page load time of an email thread, the content scroll height remained at 150 throughout the entire `ThreadView_on_load_changed` pass (because iframes are rendered lazily after the main window thread has finished?  Can't think of any other reason why this was observed). The scroll height was only found to update after the thread had finished loading, and triggering a hide/show toggle on each message.

Another option would be to use the JavaScriptCore API, and have all the logic to manipulate the height of the iframe in JS. Two possible problems with this: Firstly `enable-javascript` is explicitly disabled in Astroid's WebKit settings; second, potentially all of the `webextension` code may need to be rewritten in JS - given the huge amount of deprecation warnings when building Astroid, this likely will have to be done in anger at some point in the future anyway.

I gave up going down the path of manipulating the iframe after setting `srcdoc`, and replaced the iframe with a div instead. CSS has been fixed up and theme version bumped as it would be a breaking change for all existing users that override the theme of the UI.

I can't see any concernable difference between before and after when viewing both text/html and text/plain messages, though it is difficult to gauge as my starting point is broken messages.

The `AstroidExtension::reload_images` code path is the least tested of all the changes. The minimal check I did to see whether the logic is still fine was to send myself an email with a CID attachment, and observe it render correctly after pressing C-i in thread view.

As far as this change is concerned, this is one way to fix #720 that suits my use of Astroid. I'm not convinced that it is the correct way to go about it though, as I have no reason to dismiss the rationale for using iframes in the first place - see comments delete by this patch that make reference to style issues, deadlocks and security concerns by not having the content contained to its own iframe.