### PR TITLE
compose_message: to load as byte array, 'file' must be wrapped with copy

### DIFF
--- a/src/compose_message.cc
+++ b/src/compose_message.cc
@@ -781,7 +781,7 @@ namespace Astroid {
 
     } else {
       /* load into byte array */
-      refptr<Gio::File> fle = Glib::wrap (file, false);
+      refptr<Gio::File> fle = Glib::wrap (file, true);
       refptr<Gio::FileInputStream> istr = fle->read ();
 
       refptr<Glib::Bytes> b;


### PR DESCRIPTION
Attaching a file caused segfaults with some versions of glib. It turns out that when attaching a file, it is loaded as a byte array in `compose_message.cc`.  For this a Gio smart pointer is obtained by wrapping the GFile pointer. The wrapping has to copy, i.e. `wrap(,,, true)`, because the pointer will smartly cleanup when going out  of scope, and then also the GFile pointer when getting unreferenced. This is my explanation for this pull request.