### PR TITLE
Fix help message breaking screen layout

### DIFF
--- a/src/main_window.cc
+++ b/src/main_window.cc
@@ -788,8 +788,10 @@ namespace Astroid {
     multi_waiting = true;
     multi_keybindings = kb;
 
+#if 0
     rev_multi->set_reveal_child (true);
     label_multi->set_markup (kb.short_help ());
+#endif
 
     return true;
   }


### PR DESCRIPTION
Currently, this opens an empty sidebar on the left part of the window and displays a cut-off help message in a ribbon at the bottom of the window. The sidebar does not go away until exiting and re-opening the app. This change removes this behavior to improve usability while keeping the original intent in the code to track the feature for future contributors see the contribution opportunity.

I would also be open to deleting these lines.