### PR TITLE
Add a '#' key to send a message to the trash.

### DIFF
--- a/src/db.cc
+++ b/src/db.cc
@@ -31,7 +31,7 @@ namespace Astroid {
 
   /* static settings */
   bool Db::maildir_synchronize_flags = false;
-  std::vector<ustring> Db::excluded_tags = { "muted", "spam", "deleted" };
+  std::vector<ustring> Db::excluded_tags = { "muted", "spam", "deleted", "trash" };
   std::vector<ustring> Db::sent_tags = { "sent" };
   std::vector<ustring> Db::draft_tags = { "draft" };
   std::vector<ustring> Db::tags;

--- a/src/modes/thread_index/thread_index_list_view.cc
+++ b/src/modes/thread_index/thread_index_list_view.cc
@@ -489,6 +489,11 @@ namespace Astroid {
                              "Toggle archive",
                              bind (&ThreadIndexListView::multi_key_handler, this, MArchive, std::placeholders::_1));
 
+    multi_keys.register_key ("#",
+                             "thread_index.multi.trash",
+                             "Toggle trash",
+                             bind (&ThreadIndexListView::multi_key_handler, this, MTrash, std::placeholders::_1));
+
     multi_keys.register_key ("S",
                              "thread_index.multi.mark_spam",
                              "Toggle spam",
@@ -877,6 +882,17 @@ namespace Astroid {
           return true;
         });
 
+    keys->register_key ("#", "thread_index.trash",
+        "Toggle 'trash' tag on thread",
+        [&] (Key) {
+          auto thread = get_current_thread ();
+          if (thread) {
+            main_window->actions->doit (refptr<Action>(new ToggleAction(thread, "trash")));
+          }
+
+          return true;
+        });
+
     keys->register_key (Key (GDK_KEY_asterisk), "thread_index.flag",
         "Toggle 'flagged' tag on thread",
         [&] (Key) {
@@ -1047,6 +1063,7 @@ namespace Astroid {
       case MSpam:
       case MMute:
       case MArchive:
+      case MTrash:
       case MTag:
         {
           vector<refptr<NotmuchItem>> threads;
@@ -1068,6 +1085,10 @@ namespace Astroid {
           switch (maction) {
             case MArchive:
               a = refptr<Action>(new ToggleAction(threads, "inbox"));
+              break;
+
+            case MTrash:
+              a = refptr<Action>(new ToggleAction(threads, "trash"));
               break;
 
             case MFlag:

--- a/src/modes/thread_index/thread_index_list_view.hh
+++ b/src/modes/thread_index/thread_index_list_view.hh
@@ -85,6 +85,7 @@ namespace Astroid {
         MUnread = 0,
         MFlag,
         MArchive,
+        MTrash,
         MSpam,
         MMute,
         MToggle,

--- a/src/modes/thread_view/thread_view.cc
+++ b/src/modes/thread_view/thread_view.cc
@@ -1397,6 +1397,20 @@ namespace Astroid {
           return true;
         });
 
+    keys.register_key ("#",
+        "thread_view.trash_thread",
+        "Toggle 'trash' tag on the whole thread",
+        [&] (Key) {
+
+          if (!edit_mode && focused_message) {
+            if (thread) {
+              main_window->actions->doit (refptr<Action>(new ToggleAction(thread, "trash")));
+            }
+          }
+
+          return true;
+        });
+
     keys.register_key ("C-P",
         "thread_view.print",
         "Print focused message",
@@ -1586,6 +1600,16 @@ namespace Astroid {
         [&] (Key) {
           keys.handle ("thread_view.archive_thread");
           emit_index_action (IA_NextUnread);
+
+          return true;
+        });
+
+    next_multi.register_key ("#",
+        "thread_view.multi_next_thread.trash_thread",
+        "Trash, goto next",
+        [&] (Key) {
+          keys.handle ("thread_view.trash_thread");
+          emit_index_action (IA_Next);
 
           return true;
         });


### PR DESCRIPTION
Currently, Astroid has no support for deleting messages. Without deleting messages, a mail server with limited storage will eventually become full and incapable of receiving any more mail. Message deletion functionality in clients is an important mechanism for preventing this.

This adds a mechanism to mark messages as 'trash' in Astroid, which servers like gmail are configured to interpret as a deletion request.