### PR TITLE
Add option to disable left icons

### DIFF
--- a/src/config.cc
+++ b/src/config.cc
@@ -206,6 +206,7 @@ namespace Astroid {
     default_config.put ("thread_index.cell.date_length", 10);
     default_config.put ("thread_index.cell.message_count_length", 4);
     default_config.put ("thread_index.cell.authors_length", 20);
+    default_config.put ("thread_index.cell.show_left_icons", true);
 
     default_config.put ("thread_index.cell.subject_color", "#807d74");
     default_config.put ("thread_index.cell.subject_color_selected", "#000000");

--- a/src/modes/thread_index/thread_index_list_cell_renderer.cc
+++ b/src/modes/thread_index/thread_index_list_cell_renderer.cc
@@ -54,6 +54,7 @@ namespace Astroid {
     message_count_len = ti.get<int> ("message_count_length");
     authors_len   = ti.get<int> ("authors_length");
     tags_len      = ti.get<int> ("tags_length");
+    show_left_icons  = ti.get<bool> ("show_left_icons");
 
     subject_color = ti.get<string> ("subject_color");
     subject_color_selected = ti.get<string> ("subject_color_selected");
@@ -84,11 +85,13 @@ namespace Astroid {
       line_height     = content_height + line_spacing;
       height_set = true;
 
-      left_icons_size  = content_height - (2 * left_icons_padding);
+      left_icons_size  = show_left_icons ? content_height - (2 * left_icons_padding) : 0;
       left_icons_width = left_icons_size;
 
-      date_start          = left_icons_width_n * left_icons_width +
-          (left_icons_width_n-1) * left_icons_padding + padding;
+      date_start          = show_left_icons
+				                    ? left_icons_width_n * left_icons_width +
+          (left_icons_width_n-1) * left_icons_padding + padding
+			                      : 0;
       date_width          = char_width * date_len;
       message_count_width = char_width * message_count_len;
       message_count_start = date_start + date_width + padding;
@@ -125,10 +128,10 @@ namespace Astroid {
       render_delimiter (cr, widget, cell_area);
     */
 
-    if (thread->flagged)
+    if (thread->flagged && show_left_icons)
       render_flagged (cr, widget, cell_area);
 
-    if (thread->attachment)
+    if (thread->attachment && show_left_icons)
       render_attachment (cr, widget, cell_area);
 
     /*

--- a/src/modes/thread_index/thread_index_list_cell_renderer.hh
+++ b/src/modes/thread_index/thread_index_list_cell_renderer.hh
@@ -72,6 +72,7 @@ namespace Astroid {
       int line_height; // content_height + line_spacing
       int content_height;
       int line_spacing = 2; // configurable
+			bool show_left_icons = true; // configurable
 
       int left_icons_size;
       int left_icons_width;


### PR DESCRIPTION
Currently, there is no option to disable the left icons (e.g., attachment, urgent). However, they take up valuable screen real-estate on mobile devices. Others may simply find them less useful and want to hide the extra visual clutter.

For these reasons, this adds a config option and associated rendering logic to hide these icons upon request.