### PR TITLE
set iframe size on focus using deprecated DOM access

### DIFF
--- a/src/modes/thread_view/webextension/tvextension.hh
+++ b/src/modes/thread_view/webextension/tvextension.hh
@@ -110,6 +110,7 @@ class AstroidExtension {
     void add_message (AstroidMessages::Message &m);
     void remove_message (AstroidMessages::Message &m);
     void update_message (AstroidMessages::UpdateMessage &m);
+    void size_message_iframes ();
 
     void set_message_html (AstroidMessages::Message m,
         WebKitDOMHTMLElement * div_message);


### PR DESCRIPTION
- partly fixes #720
- alternative to removing iframes as in #740 or #732

**Problem:** iframe size is not set when a message is viewed, but only when the focus is changed after that (e.g. I open a message, it is small. Then, i type 'j'/'k' and it is correctly sized.)

**Question:** Can we call the function from some code which is called always when a message is viewed?