### PR TITLE
Use GUri instead of libsoup-2.4 and use webkit2gtk-4.1

### DIFF
--- a/.github/workflows/ci-debian-build-test.yml
+++ b/.github/workflows/ci-debian-build-test.yml
@@ -17,9 +17,6 @@ jobs:
           - image: 'debian:bullseye'
             env:
               WEBKITGTK_VERSION: '4.0'
-          - image: 'ubuntu:focal'
-            env:
-              WEBKITGTK_VERSION: '4.0'
           - image: 'debian:sid'
             env:
               WEBKITGTK_VERSION: '4.1'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,11 +95,13 @@ endif()
 
 pkg_check_modules (GTKMM3     REQUIRED  gtkmm-3.0>=3.10)
 pkg_check_modules (GLIBMM2    REQUIRED  glibmm-2.4)
-pkg_check_modules (WEBKIT2GTK REQUIRED  webkit2gtk-4.0>=2.22)
+pkg_check_modules (WEBKIT2GTK webkit2gtk-4.1)
+if (NOT WEBKIT2GTK_FOUND)
+  pkg_check_modules (WEBKIT2GTK REQUIRED webkit2gtk-4.0>=2.22)
+endif ()
 pkg_check_modules (SASS       REQUIRED  libsass)
 pkg_check_modules (GIOMM2     REQUIRED  giomm-2.4)
-pkg_check_modules (GIOUNIX    REQUIRED  gio-unix-2.0)
-pkg_check_modules (LIBSOUP    REQUIRED  libsoup-2.4)
+pkg_check_modules (GIOUNIX    REQUIRED  gio-unix-2.0>=2.66)
 
 string (REGEX REPLACE "([0-9]+\.[0-9]+)\.[0-9]+" "\\1" GMIME_MAJOR_MINOR ${Notmuch_GMIME_VERSION})
 pkg_check_modules (GMIME      REQUIRED  gmime-${GMIME_MAJOR_MINOR}>=${Notmuch_GMIME_VERSION})
@@ -154,7 +156,6 @@ include_directories (
   ${GLIBMM2_INCLUDE_DIRS}
   ${GIOMM2_INCLUDE_DIRS}
   ${GIOUNIX_INCLUDE_DIRS}
-  ${LIBSOUP_INCLUDE_DIRS}
   ${GMIME_INCLUDE_DIRS}
   ${WEBKIT2GTK_INCLUDE_DIRS}
   ${VTE2_INCLUDE_DIRS}
@@ -169,7 +170,6 @@ add_compile_options (
   ${GLIBMM2_CFLAGS}
   ${GIOMM2_CFLAGS}
   ${GIOUNIX_CFLAGS}
-  ${LIBSOUP_CFLAGS}
   ${GMIME_CFLAGS}
   ${WEBKIT2GTK_CFLAGS}
   ${VTE2_CFLAGS}
@@ -339,7 +339,6 @@ target_link_libraries (
   ${GLIBMM2_LDFLAGS}
   ${GIOMM2_LDFLAGS}
   ${GIOUNIX_LDFLAGS}
-  ${LIBSOUP_LDFLAGS}
   ${GMIME_LDFLAGS}
   ${VTE2_LDFLAGS}
   ${SASS_LDFLAGS}


### PR DESCRIPTION
This updates the URI parsing for `astroid --mailto` to use Glib instead of libsoup-2.0 (since the api was removed in libsoup-3.0).

https://libsoup.org/libsoup-3.0/migrating-from-libsoup-2.html
https://github.com/astroidmail/astroid/issues/744

I tested the mailto parsing appears to work but please double check.