### PR TITLE
em: is_regular -> is_regular_file

### DIFF
--- a/src/modes/edit_message.cc
+++ b/src/modes/edit_message.cc
@@ -1290,7 +1290,7 @@ namespace Astroid {
           for (string &fname : fnames) {
             path p (fname.c_str());
 
-            if (!is_regular (p)) {
+            if (!is_regular_file (p)) {
               LOG (error) << "em: attach: file is not regular: " << p.c_str();
             } else {
               LOG (info) << "em: attaching file: " << p.c_str();


### PR DESCRIPTION
they are the same, but is_regular_file is standard so boost removed is_regular