### PR TITLE
set iframe height in javascript

### DIFF
--- a/src/modes/thread_view/page_client.cc
+++ b/src/modes/thread_view/page_client.cc
@@ -422,11 +422,16 @@ namespace Astroid {
 
       ustring tags_s;
 
+      vector<ustring> tags = m->tags;
+      for (ustring &tag : tags) {
+        tag = Glib::Markup::escape_text (tag);
+      }
+
 # ifndef DISABLE_PLUGINS
-      if (!thread_view->plugins->format_tags (m->tags, "#ffffff", false, tags_s)) {
+      if (!thread_view->plugins->format_tags (tags, "#ffffff", false, tags_s)) {
 #  endif
 
-        tags_s = VectorUtils::concat_tags_color (m->tags, false, 0, cv);
+        tags_s = VectorUtils::concat_tags_color (tags, false, 0, cv);
 
 # ifndef DISABLE_PLUGINS
       }
@@ -434,7 +439,7 @@ namespace Astroid {
 
       msg.set_tag_string (tags_s);
 
-      for (ustring &tag : m->tags) {
+      for (ustring &tag : tags) {
         msg.add_tags (tag);
       }
     }
@@ -464,15 +469,9 @@ namespace Astroid {
       if (static_cast<int>(bp.size()) > MAX_PREVIEW_LEN)
         bp = bp.substr(0, MAX_PREVIEW_LEN - 3) + "...";
 
-      while (true) {
-        size_t i = bp.find ("<br>");
-
-        if (i == ustring::npos) break;
-
-        bp.erase (i, 4);
-      }
-
-      msg.set_preview (Glib::Markup::escape_text (bp));
+      bp = UstringUtils::replace (bp, "<br>", "");
+      bp = UstringUtils::replace (bp, "\n", "");
+      msg.set_preview (bp);
     }
 
     if (astroid->config().get<std::string> ("thread_view.preferred_type") == "plain" &&

--- a/src/modes/thread_view/page_client.hh
+++ b/src/modes/thread_view/page_client.hh
@@ -76,7 +76,7 @@ namespace Astroid {
       ustring get_attachment_thumbnail (refptr<Chunk>);
       ustring get_attachment_data (refptr<Chunk>);
 
-      static const int MAX_PREVIEW_LEN = 80;
+      static const int MAX_PREVIEW_LEN = 200;
       static const int THUMBNAIL_WIDTH        = 150; // px
       static const int ATTACHMENT_ICON_WIDTH  = 35;
       refptr<Gdk::Pixbuf> attachment_icon;

--- a/src/modes/thread_view/thread_view.cc
+++ b/src/modes/thread_view/thread_view.cc
@@ -85,7 +85,7 @@ namespace Astroid {
     webkit_web_context_set_process_model (context, WEBKIT_PROCESS_MODEL_MULTIPLE_SECONDARY_PROCESSES);
 
     websettings = WEBKIT_SETTINGS (webkit_settings_new_with_settings (
-        "enable-javascript", FALSE,
+        "enable-javascript", TRUE,
         "enable-java", FALSE,
         "enable-plugins", FALSE,
         "auto-load-images", TRUE,
@@ -99,7 +99,6 @@ namespace Astroid {
         "enable-xss-auditor", TRUE,
         "media-playback-requires-user-gesture", TRUE,
         "zoom-text-only", TRUE,
-        "enable-frame-flattening", TRUE,
 # if (DEBUG || DEBUG_WEBKIT)
         "enable-developer-extras", TRUE,
 # endif

--- a/src/modes/thread_view/webextension/tvextension.hh
+++ b/src/modes/thread_view/webextension/tvextension.hh
@@ -150,11 +150,10 @@ class AstroidExtension {
     void set_attachment_icon (WebKitDOMHTMLElement * div_message);
 
     /* headers */
-    void insert_header_date (ustring &header, AstroidMessages::Message);
-    void insert_header_address (ustring &header, ustring title, AstroidMessages::Address a, bool important);
-    void insert_header_address_list (ustring &header, ustring title, AstroidMessages::AddressList al, bool important);
-    void insert_header_row (ustring &header, ustring title, ustring value, bool important);
-    ustring create_header_row (ustring title, ustring value, bool important, bool escape, bool noprint = false);
+    void insert_header_date (WebKitDOMHTMLElement * header, AstroidMessages::Message);
+    void insert_header_address (WebKitDOMHTMLElement * header, ustring title, AstroidMessages::Address a, bool important = false);
+    void insert_header_address_list (WebKitDOMHTMLElement * header, ustring title, AstroidMessages::AddressList al, bool important = false);
+    void insert_header_row (WebKitDOMHTMLElement * header, ustring title, ustring value, bool important = false, bool html_value = false, bool noprint = false);
 
     /* warning and info */
     void set_warning (AstroidMessages::Info &);

--- a/ui/thread-view.html
+++ b/ui/thread-view.html
@@ -57,9 +57,51 @@
 </div>
 
 <div id="body_template" class="body_part">
-  <iframe class="body_iframe" sandbox srcdoc=""></iframe>
+  <!--
+    sandbox="allow-same-origin" is required, otherwise the scrollHeight of the
+    embedded document cannot be accessed.
+    Do not add 'allow-scripts' to the sandbox attribute. This would allow the
+    document to execute scripts itself.
+  -->
+  <iframe class="body_iframe" sandbox="allow-same-origin" onload="handleLoadIframe(this);" srcdoc=""></iframe>
 </div>
 
+<script>
+  function onSetFocused(element, callback) {
+    const observer = new MutationObserver((mutations) => {
+      mutations.forEach((mutation) => {
+        if (mutation.target.classList.contains("focused")) {
+          callback(mutation.target);
+        }
+      });
+    });
+
+    observer.observe(element, { attributeFilter: ["class"] });
+
+    return observer.disconnect;
+  }
+
+  function sizeIframe(iframe) {
+    iframe.height = 0; // hack, no idea why it only works with this
+    iframe.height = iframe.contentWindow.document.body.scrollHeight;
+  }
+
+  function getParentWithClass(element, c) {
+    p = element.parentElement;
+    while (p != document.body && !p.classList.contains(c)) {
+      p = p.parentElement;
+    }
+
+    return p;
+  }
+
+  function handleLoadIframe(iframe) {
+    sizeIframe(iframe);
+    const email = getParentWithClass(iframe, "email");
+    if (email != document.body)
+      onSetFocused(email, _ => sizeIframe(iframe));
+  };
+</script>
 
 </body>
 </html>

--- a/ui/thread-view.scss
+++ b/ui/thread-view.scss
@@ -852,11 +852,29 @@ body.nohide .email .compressed_note > span {
     color: black;
     text-decoration: none;
 }
+.header .field .address_list {
+  display: inline;
+  list-style: none;
+  padding-left: 0;
+  margin-left: 0;
+}
+.header .field .address_list li {
+  display: inline;
+}
+.header .field .address_list li + li:before {
+  content: ", ";
+}
 .header .field.important .address_name {
     font-weight: bold;
 }
 .header .field .address_value {
     color: #777;
+}
+.header .field .address_value:before {
+  content: "<";
+}
+.header .field .address_value:after {
+  content: ">";
 }
 
 .geary_spacer {

--- a/ui/thread-view.scss
+++ b/ui/thread-view.scss
@@ -334,6 +334,7 @@ hr {
     text-overflow: ellipsis;
     overflow: hidden;
     margin-left: 48px;
+    //max-width: 80ex; // old behavior
 }
 
 .email_container .header_container .tags {


### PR DESCRIPTION
- fixes #720, fixes #736
- closes #732, closes #740, closes #743

This does not allow the document (message content) to execute javascript, as can be verified with the following email, which displays "no scripts" by default, but "scripts active" when js is active.

```
Date: Tue, 1 January 1970 00:00:00 +0000
From:
Subject:
MIME-Version: 1.0
Content-Type: multipart/alternative; boundary="=-TUjG03Ah9OcLtWE56Ucm"

--=-TUjG03Ah9OcLtWE56Ucm
Content-Type: text/plain; charset=utf-8
Content-Transfer-Encoding: quoted-printable

<div id=3D"jscontent">
  no scripts
</div>

<script>
  d =3D document.getElementById('jscontent');
  d.innerHTML =3D "scripts active";
</script>

--=-TUjG03Ah9OcLtWE56Ucm
Content-Type: text/html; charset=utf-8
Content-Transfer-Encoding: quoted-printable

<!DOCTYPE html>
<html xmlns=3D"http://www.w3.org/1999/xhtml" lang xml:lang>
<head>
  <meta charset=3D"utf-8" />
  <meta name=3D"generator" content=3D"pandoc" />
  <meta name=3D"viewport" content=3D"width=3Ddevice-width, initial-scale=3D=
1.0, user-scalable=3Dyes" />
  <style>
code{white-space: pre-wrap;}
span.smallcaps{font-variant: small-caps;}
span.underline{text-decoration: underline;}
div.column{display: inline-block; vertical-align: top; width: 50%;}
</style>
</head>
<body>
<div id=3D"jscontent">
<p>no scripts</p>
</div>
<script>
  d =3D document.getElementById('jscontent');
  d.innerHTML =3D "scripts active";
</script>
</body>
</html>

--=-TUjG03Ah9OcLtWE56Ucm--
```