### PR TITLE
Fix help message for actions on multi-message-selection

### DIFF
--- a/src/main_window.cc
+++ b/src/main_window.cc
@@ -788,10 +788,8 @@ namespace Astroid {
     multi_waiting = true;
     multi_keybindings = kb;
 
-#if 0
     rev_multi->set_reveal_child (true);
     label_multi->set_markup (kb.short_help ());
-#endif
 
     return true;
   }

--- a/src/main_window.cc
+++ b/src/main_window.cc
@@ -162,6 +162,7 @@ namespace Astroid {
     label_multi = Gtk::manage (new Gtk::Label ());
     rh_->pack_start (*label_multi, true, true, 5);
     label_multi->set_halign (Gtk::ALIGN_START);
+    label_multi->set_line_wrap();
 
     rev_multi->set_margin_top (0);
     rh->set_margin_bottom (5);


### PR DESCRIPTION
This reverts commit 8f2a8aeefd634c3f861ba51f7ca5fe256c7350b1.

There is no other place in the code that calls `rev_multi->set_reveal_child(true)`, so the consequence of this change was that the `;` key no longer shows the revealer bar.


Before this PR:
![image](https://github.com/astroidmail/astroid/assets/397929/6cb19a3e-af8c-4662-8915-8987d1a74048)


After this PR:
![image](https://github.com/astroidmail/astroid/assets/397929/f1df6775-d659-43a4-94e2-330c09f84b2a)