### PR TITLE
Set margin_top on the revealer bars in addition to margin_bottom

### DIFF
--- a/src/main_window.cc
+++ b/src/main_window.cc
@@ -145,6 +145,7 @@ namespace Astroid {
 
     rev_yes_no->set_margin_top (0);
     rh->set_margin_bottom (5);
+    rh->set_margin_top (5);
 
     rev_yes_no->add (*rh);
     rev_yes_no->set_reveal_child (false);
@@ -164,7 +165,8 @@ namespace Astroid {
     label_multi->set_halign (Gtk::ALIGN_START);
 
     rev_multi->set_margin_top (0);
-    rh->set_margin_bottom (5);
+    rh_->set_margin_bottom (5);
+    rh_->set_margin_top (5);
 
     rev_multi->add (*rh_);
     rev_multi->set_reveal_child (false);

--- a/src/main_window.cc
+++ b/src/main_window.cc
@@ -144,8 +144,8 @@ namespace Astroid {
     rh->pack_start (*no, false, true, 5);
 
     rev_yes_no->set_margin_top (0);
-    rh->set_margin_bottom (5);
-    rh->set_margin_top (5);
+    rh->set_margin_bottom (3);
+    rh->set_margin_top (3);
 
     rev_yes_no->add (*rh);
     rev_yes_no->set_reveal_child (false);


### PR DESCRIPTION
1. Sets equal margins on both top and bottom, which (to me) has a better aesthetic look to it.
2. I noticed that there was a typo in the code which meant the bulk update ("multi") revealer never got a margin set.

---

Before this PR:

![image](https://github.com/astroidmail/astroid/assets/397929/1c096b61-daf3-4aa8-817d-78c0400ceb8e)

![image](https://github.com/astroidmail/astroid/assets/397929/e693de79-c3a8-46db-9ad3-b5736cf3af01)

---

After this PR:

![image](https://github.com/astroidmail/astroid/assets/397929/f0eb6932-6bb5-47b3-92a9-29ee10d8bb45)

![image](https://github.com/astroidmail/astroid/assets/397929/3a4ce73b-d2fb-48f1-ad0a-be88c40ad534)

---

