### PR TITLE
Default initialize all pointers in Astroid class to avoid segfault in dtor

### DIFF
--- a/src/astroid.hh
+++ b/src/astroid.hh
@@ -63,17 +63,17 @@ namespace Astroid {
       ustring user_agent;
 
       /* accounts */
-      AccountManager * accounts;
+      AccountManager * accounts = NULL;
 
       /* actions */
-      ActionManager * actions;
+      ActionManager * actions = NULL;
 
 # ifndef DISABLE_PLUGINS
-      PluginManager * plugin_manager;
+      PluginManager * plugin_manager = NULL;
 # endif
 
       /* poll */
-      Poll * poll;
+      Poll * poll = NULL;
 
       MainWindow * open_new_window (bool open_defaults = true);
 
@@ -81,7 +81,7 @@ namespace Astroid {
       GdkAtom clipboard_target = GDK_SELECTION_CLIPBOARD;
 
     protected:
-      Config * m_config;
+      Config * m_config = NULL;
 
     private:
       void on_activate () override;

--- a/src/db.cc
+++ b/src/db.cc
@@ -81,6 +81,13 @@ namespace Astroid {
       maildir_synchronize_flags = config.get<bool> ("maildir.synchronize_flags");
     } catch (const boost::property_tree::ptree_bad_path &ex) {
       throw database_error ("db: error: no maildir.maildir_synchronize_flags defined in notmuch-config");
+    } catch (const boost::property_tree::ptree_bad_data &ex) {
+      ustring bad_data_s = config.get<string> ("maildir.synchronize_flags");
+      if (bad_data_s != "") {
+        LOG (error) << "db: error: bad argument '" << bad_data_s << "' "
+          << "for maildir.maildir_synchronize_flags in notmuch-config "
+          << "(expected yes/no)";
+      }
     }
   }
 


### PR DESCRIPTION
Under certain circumstances - both deterministic and non-deterministic - astroid can segfault on exit.

For example, when there's another window already running:
```
$ astroid & bg
[2024-06-05 16:18:20.526090] [0x0000706fccadcec0] [info]    welcome to astroid! - v0.16-20-g41808e88
...
[16:18:20] [0x0000706fccadcec0] [M] [debug] log: stdout: yes

$ astroid 
[2024-06-05 16:20:26.487138] [0x00007f11b1bbaec0] [info]    welcome to astroid! - v0.16-20-g41808e88
Segmentation fault (core dumped)
```

In all cases the cause is at least one of these pointers pointing at garbage due to being uninitialised.