### PR TITLE
Stop using deprecated Gtk::HBox

### DIFF
--- a/src/main_window.hh
+++ b/src/main_window.hh
@@ -42,7 +42,7 @@ namespace Astroid {
       static int icon_size;
 
     private:
-      Gtk::HBox icons;
+      Gtk::Box icons;
       Gtk::Spinner poll_spinner;
       bool spinner_on = false;
 


### PR DESCRIPTION
GtkHBox has been deprecated since GTK 3.2.  No further changes are needed, since the default value of the GtkOrientable:orientation property is GTK_ORIENTATION_HORIZONTAL.

(See: https://docs.gtk.org/gtk3/class.HBox.html)