### PR TITLE
Call set_size_request on pane children

### DIFF
--- a/src/modes/paned_mode.cc
+++ b/src/modes/paned_mode.cc
@@ -55,7 +55,7 @@ namespace Astroid {
 
     Gtk::EventBox * fb = Gtk::manage (new Gtk::EventBox ());
     fb->add (*w);
-    fb->set_size_request (300);
+    fb->set_size_request (50);
 
     if (p == 0) {
       fp1 = fb;

--- a/src/modes/paned_mode.cc
+++ b/src/modes/paned_mode.cc
@@ -55,6 +55,7 @@ namespace Astroid {
 
     Gtk::EventBox * fb = Gtk::manage (new Gtk::EventBox ());
     fb->add (*w);
+    fb->set_size_request (300);
 
     if (p == 0) {
       fp1 = fb;


### PR DESCRIPTION
Otherwise the second child gets no width, and appears to be hidden when a thread is opened in pane view.

The number `300` is pretty arbitrary, it's taken as 1/4 of the default window width ([set here](https://github.com/astroidmail/astroid/blob/c1e5cdbd662e2bcfef2fe5dc72dbc444a692a0e8/src/main_window.cc#L105)).

Fixes #547