### PR TITLE
Use libnotmuch config api

### DIFF
--- a/.github/workflows/ci-debian-build-test.yml
+++ b/.github/workflows/ci-debian-build-test.yml
@@ -14,19 +14,13 @@ jobs:
           - image: 'debian:stable'
             env:
               WEBKITGTK_VERSION: '4.0'
-          - image: 'debian:bullseye'
-            env:
-              WEBKITGTK_VERSION: '4.0'
-          - image: 'ubuntu:focal'
-            env:
-              WEBKITGTK_VERSION: '4.0'
           - image: 'debian:sid'
             env:
               WEBKITGTK_VERSION: '4.1'
-          - image: 'ubuntu:devel'
+          - image: 'ubuntu:noble'
             env:
               WEBKITGTK_VERSION: '4.1'
-          - image: 'ubuntu:noble'
+          - image: 'ubuntu:devel'
             env:
               WEBKITGTK_VERSION: '4.1'
     timeout-minutes: 15

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,8 +79,8 @@ message (STATUS "Building ${PROJECT_NAME} ${PROJECT_VERSION}")
 # check for required packages and libraries
 #
 find_package( Notmuch REQUIRED )
-if (Notmuch_INDEX_FILE_API)
-  add_definitions ( -DHAVE_NOTMUCH_INDEX_FILE )
+if (NOT Notmuch_VERSION VERSION_GREATER_EQUAL "5.4")
+    message (FATAL_ERROR "libnotmuch >= 5.4 must be installed.")
 endif()
 
 find_package ( PkgConfig REQUIRED )

--- a/cmake/FindNotmuch.cmake
+++ b/cmake/FindNotmuch.cmake
@@ -6,7 +6,6 @@
 #  Notmuch_INCLUDE_DIRS   - the Notmuch include directories
 #  Notmuch_LIBRARIES      - link these to use Notmuch
 #  Notmuch_GMIME_VERSION  - the GMime version notmuch was linked against
-#  Notmuch_INDEX_FILE_API - whether Notmuch has the notmuch_database_index_file() API
 
 include (LibFindMacros)
 
@@ -65,7 +64,6 @@ libfind_process (Notmuch)	# will set Notmuch_FOUND, Notmuch_INCLUDE_DIRS and Not
 include (CheckSymbolExists)
 set (CMAKE_REQUIRED_INCLUDES ${Notmuch_INCLUDE_DIR})
 set (CMAKE_REQUIRED_LIBRARIES ${Notmuch_LIBRARY})
-check_symbol_exists (notmuch_database_index_file notmuch.h Notmuch_INDEX_FILE_API)
 
 # GMime version notmuch was linked against
 include (GetPrerequisites)

--- a/src/astroid.cc
+++ b/src/astroid.cc
@@ -342,8 +342,8 @@ namespace Astroid {
     return m_config->config.get_child(id);
   }
 
-  const boost::property_tree::ptree& Astroid::notmuch_config () const {
-    return m_config->notmuch_config;
+  const boost::filesystem::path& Astroid::notmuch_config () const {
+    return m_config->notmuch_config_path;
   }
 
   const StandardPaths& Astroid::standard_paths() const {

--- a/src/astroid.hh
+++ b/src/astroid.hh
@@ -8,6 +8,7 @@
 # include <boost/property_tree/ptree.hpp>
 # include <boost/program_options.hpp>
 # include <boost/log/trivial.hpp>
+# include <boost/filesystem.hpp>
 
 # define LOG(x) BOOST_LOG_TRIVIAL(x)
 # define warn warning
@@ -53,7 +54,7 @@ namespace Astroid {
 
 
       const boost::property_tree::ptree& config (const std::string& path=std::string()) const;
-      const boost::property_tree::ptree& notmuch_config () const;
+      const boost::filesystem::path& notmuch_config () const;
       const StandardPaths& standard_paths() const;
             RuntimePaths& runtime_paths() const;
       bool  has_notmuch_config ();

--- a/src/config.cc
+++ b/src/config.cc
@@ -319,13 +319,11 @@ namespace Astroid {
       config.put ("poll.interval", 0);
       config.put ("accounts.charlie.gpgkey", "gaute@astroidmail.bar");
       config.put ("mail.send_delay", 0);
-      std::string test_nmcfg_path;
       if (getenv ("ASTROID_BUILD_DIR")) {
-        test_nmcfg_path = (current_path () / path ("tests/mail/test_config")).string();
+        notmuch_config_path = (current_path () / path ("tests/mail/test_config"));
       } else {
-        test_nmcfg_path = (Resource::get_exe_dir () / path ("tests/mail/test_config")).string();
+        notmuch_config_path = (Resource::get_exe_dir () / path ("tests/mail/test_config")).string();
       }
-      boost::property_tree::read_ini (test_nmcfg_path, notmuch_config);
       has_notmuch_config = true;
       return;
     }
@@ -376,8 +374,7 @@ namespace Astroid {
     std_paths.attach_dir = Utils::expand(bfs::path (config.get<string>("editor.attachment_directory")));
     run_paths.attach_dir = std_paths.attach_dir;
 
-    /* read notmuch config */
-    bfs::path notmuch_config_path;
+    /* search for notmuch config file */
     char * notmuch_config_env = getenv ("NOTMUCH_CONFIG");
     if (notmuch_config_env) {
       notmuch_config_path = Utils::expand(bfs::path (notmuch_config_env));
@@ -386,9 +383,6 @@ namespace Astroid {
     }
 
     if (is_regular_file (notmuch_config_path)) {
-      boost::property_tree::read_ini (
-        notmuch_config_path.c_str(),
-        notmuch_config);
       has_notmuch_config = true;
     } else {
       has_notmuch_config = false;

--- a/src/config.cc
+++ b/src/config.cc
@@ -161,13 +161,6 @@ namespace Astroid {
     ptree default_config;
     default_config.put ("astroid.config.version", CONFIG_VERSION);
 
-    std::string nm_cfg = path(std_paths.home / path (".notmuch-config")).string();
-    char* nm_env = getenv("NOTMUCH_CONFIG");
-    if (nm_env != NULL) {
-      nm_cfg.assign(nm_env, strlen(nm_env));
-    }
-    default_config.put ("astroid.notmuch_config" , nm_cfg);
-
     default_config.put ("astroid.debug.dryrun_sending", false);
 
     /* only show hints with a level higher than this */

--- a/src/config.hh
+++ b/src/config.hh
@@ -55,8 +55,8 @@ namespace Astroid {
       void write_back_config ();
 
       ptree config;
-      ptree notmuch_config;
-      bool has_notmuch_config;
+      bfs::path notmuch_config_path;
+      bool has_notmuch_config = false;
 
       const int CONFIG_VERSION = 11;
 

--- a/src/db.hh
+++ b/src/db.hh
@@ -16,19 +16,6 @@
 # include "config.hh"
 # include "proto.hh"
 
-/* there was a bit of a round-dance of with the _st versions of these returning
- * to the old name, but with different signature */
-# if (LIBNOTMUCH_MAJOR_VERSION < 5)
-# define notmuch_query_search_threads(x,y) notmuch_query_search_threads_st(x,y)
-# define notmuch_query_count_threads(x,y) notmuch_query_count_threads_st(x,y)
-# define notmuch_query_search_messages(x,y) notmuch_query_search_messages_st(x,y)
-# define notmuch_query_count_messages(x,y) notmuch_query_count_messages_st(x,y)
-# endif
-
-# ifndef HAVE_NOTMUCH_INDEX_FILE
-# define notmuch_database_index_file(d,f,o,m) notmuch_database_add_message(d,f,m)
-# endif
-
 namespace Astroid {
   class NotmuchItem : public Glib::Object {
     public:
@@ -163,6 +150,7 @@ namespace Astroid {
       static bool maildir_synchronize_flags;
       static void init ();
       static bfs::path path_db;
+      static bfs::path path_config;
 
     private:
       /*

--- a/src/db.hh
+++ b/src/db.hh
@@ -150,7 +150,7 @@ namespace Astroid {
       static bool maildir_synchronize_flags;
       static void init ();
       static bfs::path path_db;
-      static bfs::path path_config;
+      static const char * path_config;
 
     private:
       /*

--- a/tests/test_notmuch.cc
+++ b/tests/test_notmuch.cc
@@ -27,7 +27,7 @@ BOOST_AUTO_TEST_SUITE(Notmuch)
       notmuch_database_open_with_config (
         path_db.c_str(),
         notmuch_database_mode_t::NOTMUCH_DATABASE_MODE_READ_ONLY,
-        NULL, NULL, &nm_db, NULL);
+        "", NULL, &nm_db, NULL);
 
 
     BOOST_CHECK (s == NOTMUCH_STATUS_SUCCESS);

--- a/tests/test_notmuch.cc
+++ b/tests/test_notmuch.cc
@@ -24,10 +24,10 @@ BOOST_AUTO_TEST_SUITE(Notmuch)
     notmuch_database_t * nm_db;
 
     notmuch_status_t s =
-      notmuch_database_open (
+      notmuch_database_open_with_config (
         path_db.c_str(),
         notmuch_database_mode_t::NOTMUCH_DATABASE_MODE_READ_ONLY,
-        &nm_db);
+        NULL, NULL, &nm_db, NULL);
 
 
     BOOST_CHECK (s == NOTMUCH_STATUS_SUCCESS);
@@ -76,10 +76,10 @@ BOOST_AUTO_TEST_SUITE(Notmuch)
     notmuch_database_t * nm_db;
 
     notmuch_status_t s =
-      notmuch_database_open (
+      notmuch_database_open_with_config (
         path_db.c_str(),
         notmuch_database_mode_t::NOTMUCH_DATABASE_MODE_READ_ONLY,
-        &nm_db);
+        "", NULL, &nm_db, NULL);
 
 
     BOOST_CHECK (s == NOTMUCH_STATUS_SUCCESS);

--- a/tests/test_notmuch_standalone.cc
+++ b/tests/test_notmuch_standalone.cc
@@ -6,16 +6,6 @@
 
 // Build with: g++ test_notmuch_standalone.cc -o test_notmuch_standalone -lnotmuch
 
-
-/* there was a bit of a round-dance of with the _st versions of these returning
- * to the old name, but with different signature */
-# if (LIBNOTMUCH_MAJOR_VERSION < 5)
-# define notmuch_query_search_threads(x,y) notmuch_query_search_threads_st(x,y)
-# define notmuch_query_count_threads(x,y) notmuch_query_count_threads_st(x,y)
-# define notmuch_query_search_messages(x,y) notmuch_query_search_messages_st(x,y)
-# define notmuch_query_count_messages(x,y) notmuch_query_count_messages_st(x,y)
-# endif
-
 using std::cout;
 using std::endl;
 
@@ -25,10 +15,10 @@ int main () {
   notmuch_database_t * nm_db;
 
   notmuch_status_t s =
-    notmuch_database_open (
+    notmuch_database_open_with_config (
       path_db,
       notmuch_database_mode_t::NOTMUCH_DATABASE_MODE_READ_ONLY,
-      &nm_db);
+      "", NULL, &nm_db, NULL);
 
   (void) (s);
 
@@ -108,10 +98,10 @@ int main () {
    * continue loading the original query */
   notmuch_database_t * nm_db2;
 
-  s = notmuch_database_open (
+  s = notmuch_database_open_with_config (
       path_db,
       notmuch_database_mode_t::NOTMUCH_DATABASE_MODE_READ_WRITE,
-      &nm_db2);
+      "", NULL, &nm_db2, NULL);
 
 
   char qry_s[256];
@@ -152,10 +142,10 @@ int main () {
   notmuch_database_close (nm_db2);
 
   /* re-add unread tag */
-  s = notmuch_database_open (
+  s = notmuch_database_open_with_config (
       path_db,
       notmuch_database_mode_t::NOTMUCH_DATABASE_MODE_READ_WRITE,
-      &nm_db2);
+      "", NULL, &nm_db2, NULL);
 
 
 

--- a/tests/test_open_db.cc
+++ b/tests/test_open_db.cc
@@ -17,7 +17,6 @@ BOOST_AUTO_TEST_SUITE(DbTest)
   BOOST_AUTO_TEST_CASE(open_confirm)
   {
     setup ();
-    const_cast<ptree&>(astroid->notmuch_config()).put ("database.path", "tests/mail/test_mail");
 
     Db * db;
 
@@ -33,7 +32,6 @@ BOOST_AUTO_TEST_SUITE(DbTest)
   BOOST_AUTO_TEST_CASE(open_rw)
   {
     setup ();
-    const_cast<ptree&>(astroid->notmuch_config()).put ("database.path", "tests/mail/test_mail");
 
     Db * db;
 


### PR DESCRIPTION
- close #756
- close #714
- require libnotmuch >= 5.4 / notmuch >= 0.32
- drop ci support for Debian bullseye and Ubuntu focal because of too old libnotmuch

@ibuclaw
- Thank you for your patch, which is the main part of this!
- Could you review my little changes? To me the tests looked fine except for the fix in 4bd20ed539e03b21009bbead7a685cf4143691b7. Also, they run successfully.

@gauteh Do you have an opinion on this, especially on the tests?