### PR TITLE
CMakeLists.txt: remove boost_system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,7 +116,6 @@ find_package ( Boost REQUIRED
   log
   thread
   date_time
-  system
   )
 
 find_package (Protobuf CONFIG)


### PR DESCRIPTION
otherwise build fails on boost 1.89: https://github.com/boostorg/boost/issues/1071. build and run successful after this change.