### PR TITLE
Fix astroid webextension process crashing in thread view

### DIFF
--- a/.github/workflows/ci-debian-build-test.yml
+++ b/.github/workflows/ci-debian-build-test.yml
@@ -11,6 +11,10 @@ jobs:
       fail-fast: false
       matrix:
         container:
+          # sid fails in install build dependencies step
+          #- image: 'debian:sid'
+          #  env:
+          #    WEBKITGTK_VERSION: '4.1'
           - image: 'debian:stable'
             env:
               WEBKITGTK_VERSION: '4.1'
@@ -20,18 +24,18 @@ jobs:
           - image: 'debian:bullseye'
             env:
               WEBKITGTK_VERSION: '4.0'
-          - image: 'ubuntu:focal'
-            env:
-              WEBKITGTK_VERSION: '4.0'
-          - image: 'debian:sid'
-            env:
-              WEBKITGTK_VERSION: '4.1'
           - image: 'ubuntu:devel'
             env:
               WEBKITGTK_VERSION: '4.1'
           - image: 'ubuntu:noble'
             env:
               WEBKITGTK_VERSION: '4.1'
+          - image: 'ubuntu:jammy'
+            env:
+              WEBKITGTK_VERSION: '4.1'
+          - image: 'ubuntu:focal'
+            env:
+              WEBKITGTK_VERSION: '4.0'
     timeout-minutes: 15
     steps:
       - name: Git checkout

--- a/src/modes/thread_view/page_client.cc
+++ b/src/modes/thread_view/page_client.cc
@@ -72,11 +72,15 @@ namespace Astroid {
 
     LOG (debug) << "pc: closing";
 
-    istream.clear ();
-    ostream.clear ();
+    if (ready) {
+      istream.clear ();
+      ostream.clear ();
 
-    ext->close ();
-    srv->close ();
+      ext->close ();
+    }
+    if (srv) {
+      srv->close ();
+    }
   }
 
   void PageClient::init_web_extensions (WebKitWebContext * context) {

--- a/src/modes/thread_view/webextension/tvextension.cc
+++ b/src/modes/thread_view/webextension/tvextension.cc
@@ -124,9 +124,14 @@ AstroidExtension::AstroidExtension (
 {
   extension = e;
 
-  Glib::init ();
+  /* initializes glib, gio, gdk, and gtk */
   Gtk::Main::init_gtkmm_internals ();
-  Gio::init ();
+  /* open the default display */
+  if (!Gdk::Display::get_default ()) {
+    auto display = Gdk::Display::open ("");
+    g_assert (display);
+  }
+
   logging::add_common_attributes ();
 
   /* load attachment icon */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -53,4 +53,5 @@ add_astroid_test (dates               test_dates               test_dates.cc    
 add_astroid_test (crypto              test_crypto              test_crypto.cc             )
 add_astroid_test (gmime_version       test_gmime_version       test_gmime_version.cc      )
 add_astroid_test (quote_html          test_quote_html          test_quote_html.cc )
+add_astroid_test (webextension        test_webextension        test_webextension.cc )
 

--- a/tests/test_webextension.cc
+++ b/tests/test_webextension.cc
@@ -7,7 +7,6 @@
 
 # include "test_common.hh"
 
-# include "modes/thread_view/theme.hh"
 # include "utils/ustring_utils.hh"
 
 namespace bfs = boost::filesystem;
@@ -131,7 +130,7 @@ public:
             g_object_ref_sink (webview);
 
         webkit_web_view_load_html (webview,
-                                   Astroid::Theme ().thread_view_html.c_str (),
+                                   "<html><head></head><body>WebExtension</body></html>",
                                    Astroid::UstringUtils::random_alphanumeric (30).c_str ());
     }
 

--- a/tests/test_webextension.cc
+++ b/tests/test_webextension.cc
@@ -1,0 +1,162 @@
+# define BOOST_TEST_DYN_LINK
+# define BOOST_TEST_MODULE TestWebExtension
+# include <boost/test/unit_test.hpp>
+# include <boost/filesystem.hpp>
+
+# include <webkit2/webkit2.h>
+
+# include "test_common.hh"
+
+# include "modes/thread_view/theme.hh"
+# include "utils/ustring_utils.hh"
+
+namespace bfs = boost::filesystem;
+
+class TestClient : public sigc::trackable
+{
+public:
+    WebKitWebView *webview;
+    WebKitSettings *websettings;
+    WebKitWebContext *context;
+    refptr<Gio::SocketListener> srv;
+    refptr<Gio::UnixConnection> ext;
+    gulong extension_connect_id;
+    GMainLoop *main_loop;
+
+    void run_loop ()
+    {
+        LOG (info) << "test: start main loop";
+        g_main_loop_run (main_loop);
+    }
+
+    void quit_loop ()
+    {
+        LOG (info) << "test: quit main loop";
+        g_main_loop_quit (main_loop);
+    }
+
+    void extension_connect (refptr<Gio::AsyncResult> &res)
+    {
+        LOG (info) << "test: got web extension connect";
+        ext = refptr<Gio::UnixConnection>::cast_dynamic (srv->accept_finish (res));
+    }
+
+    void init_web_extensions (WebKitWebContext * context)
+    {
+        bfs::path test_dir = bfs::system_complete (bfs::path ("."));
+        bfs::path build_dir = test_dir.parent_path ();
+        BOOST_CHECK (exists (build_dir / bfs::path ("libtvextension.so")));
+
+        webkit_web_context_set_web_extensions_directory (context, build_dir.c_str ());
+
+        ustring socket_addr = ustring::compose ("%1/astroid.%2",
+                                                test_dir.c_str (),
+                                                Astroid::UstringUtils::random_alphanumeric (30));
+        refptr<Gio::UnixSocketAddress> addr;
+        if (Gio::UnixSocketAddress::abstract_names_supported ())
+            addr = Gio::UnixSocketAddress::create (socket_addr,
+                                                   Gio::UNIX_SOCKET_ADDRESS_ABSTRACT);
+        else
+            addr = Gio::UnixSocketAddress::create (socket_addr,
+                                                   Gio::UNIX_SOCKET_ADDRESS_PATH);
+
+        mode_t p = umask (0077);
+        srv = Gio::SocketListener::create ();
+        refptr<Gio::SocketAddress> eaddr;
+
+        srv->add_address (addr, Gio::SocketType::SOCKET_TYPE_STREAM,
+                          Gio::SocketProtocol::SOCKET_PROTOCOL_DEFAULT,
+                          eaddr);
+
+        srv->accept_async (sigc::mem_fun (this, &TestClient::extension_connect));
+        umask (p);
+
+        GVariant *gaddr = g_variant_new_string (addr->get_path ().c_str ());
+        webkit_web_context_set_web_extensions_initialization_user_data (context, gaddr);
+    }
+
+    static void on_web_extensions (WebKitWebContext *context, GVariant *user_data)
+    {
+        LOG (info) << "test: called initialize-web-extensions";
+        ((TestClient *) user_data)->init_web_extensions (context);
+    }
+
+    static void on_load_changed (WebKitWebView *webview,
+                                 WebKitLoadEvent load_event,
+                                 TestClient *test)
+    {
+        LOG (info) << "test: called load-changed";
+        if (load_event != WEBKIT_LOAD_FINISHED)
+            return;
+        g_signal_handlers_disconnect_by_func (webview,
+                                              (gpointer) TestClient::on_load_changed,
+                                              test);
+        test->quit_loop ();
+    }
+
+    static gboolean wait_failed (gpointer user_data)
+    {
+        bool wait_timed_out = false;
+        ((TestClient *) user_data)->quit_loop ();
+        BOOST_CHECK (wait_timed_out);
+        return G_SOURCE_REMOVE;
+    }
+
+    void wait (double seconds)
+    {
+        g_timeout_add (seconds * 1000, TestClient::wait_failed, this);
+        g_signal_connect (webview, "load-changed",
+                          G_CALLBACK (TestClient::on_load_changed),
+                          (gpointer) this);
+        run_loop ();
+    }
+
+    TestClient ()
+    {
+        context = webkit_web_context_new_ephemeral ();
+        extension_connect_id = g_signal_connect (context,
+                                                 "initialize-web-extensions",
+                                                 G_CALLBACK (TestClient::on_web_extensions),
+                                                 (gpointer) this);
+        main_loop = g_main_loop_new (nullptr, true);
+
+        websettings = WEBKIT_SETTINGS (webkit_settings_new_with_settings (NULL));
+
+        webview = WEBKIT_WEB_VIEW (g_object_new (WEBKIT_TYPE_WEB_VIEW,
+                                                 "web-context", context,
+                                                 "settings", websettings,
+                                                 NULL));
+
+        if (g_object_is_floating (webview))
+            g_object_ref_sink (webview);
+
+        webkit_web_view_load_html (webview,
+                                   Astroid::Theme ().thread_view_html.c_str (),
+                                   Astroid::UstringUtils::random_alphanumeric (30).c_str ());
+    }
+
+    ~TestClient ()
+    {
+        g_signal_handler_disconnect (context, extension_connect_id);
+        if (ext) ext->close ();
+        if (srv) srv->close ();
+        g_object_unref (context);
+        g_object_unref (websettings);
+        g_object_unref (webview);
+    }
+};
+
+BOOST_AUTO_TEST_SUITE(WebExtension)
+
+    BOOST_AUTO_TEST_CASE(page_client)
+    {
+        setup ();
+
+        auto client = new TestClient ();
+        client->wait (10);
+        delete client;
+
+        teardown ();
+    }
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Not sure what caused this to occur, looking at local system upgrade history, webkit2gtk recently got updated from 2.50.4 to 2.52.3.

To reproduce, open any email in a new thread view, and the new tab is just a blank white page that doesn't respond to any keybindings.  Closing astroid then results in a segfault inside the dtor for `PageClient`.

First sign that something is going wrong was this error in the console.
```
(process:170163): Gtk-CRITICAL **: 18:16:38.827: gtk_icon_theme_get_for_screen: assertion 'GDK_IS_SCREEN (screen)' failed
```
Which occurs inside the call to `Gtk::IconTheme::get_default();`
https://github.com/astroidmail/astroid/blob/master/src/modes/thread_view/webextension/tvextension.cc#L133

Subsequently, the return value assigned to `theme` is `NULL`. Which then results in the web extension thread dying due to the null dereference on the next line of code.

As far as I can tell, this static method expects the default screen to have already been opened, and adding an assert confirmed that no display is open inside the web extension thread.
```
g_assert (Gdk::Display::get_default ());

$ ./build/astroid
...
ERROR:astroid/src/modes/thread_view/webextension/tvextension.cc:132:AstroidExtension::AstroidExtension(WebKitWebExtension*, gpointer): assertion failed: (Gdk::Display::get_default ())
Bail out! ERROR:astroid/src/modes/thread_view/webextension/tvextension.cc:132:AstroidExtension::AstroidExtension(WebKitWebExtension*, gpointer): assertion failed: (Gdk::Display::get_default ())
```

This change reflects some observations from looking within gtk and gdk itself.

https://github.com/GNOME/gtkmm/blob/2160941ea7e63daa74782e53c7089659b5628293/gtk/gtkmm/init.cc#L28

https://github.com/GNOME/gtk/blob/0e4930b10bdee987d1e79cdc11494c953f621433/gdk/gdk.c#L371